### PR TITLE
nemos-images-reference-lunar: x86, aarch64: add iptables

### DIFF
--- a/nemos-images-reference-lunar/aarch64/appliance.kiwi
+++ b/nemos-images-reference-lunar/aarch64/appliance.kiwi
@@ -113,6 +113,7 @@
         <package name="linuxptp" />
         <package name="udhcpd" />
         <package name="udhcpc" />
+        <package name="iptables" />
     </packages>
 
     <packages type="image" profiles="development">

--- a/nemos-images-reference-lunar/x86/appliance.kiwi
+++ b/nemos-images-reference-lunar/x86/appliance.kiwi
@@ -54,7 +54,7 @@
     </users>
 
     <repository type="apt-deb" alias="NemOS-Bootstrap-PPA" distribution="lunar" components="main"
-        repository_gpgcheck="false" profiles="bootstrapped">
+        repository_gpgcheck="false" profiles="bootstrapped,development">
         <source path="https://ppa.launchpadcontent.net/nemos-team/bootstrap/ubuntu" />
     </repository>
     <repository type="apt-deb" alias="NemOS-PPA" distribution="lunar" components="main"

--- a/nemos-images-reference-lunar/x86/appliance.kiwi
+++ b/nemos-images-reference-lunar/x86/appliance.kiwi
@@ -113,6 +113,7 @@
         <package name="linuxptp" />
         <package name="udhcpd" />
         <package name="udhcpc" />
+        <package name="iptables" />
     </packages>
 
     <packages type="image" profiles="development">


### PR DESCRIPTION
This adds the missing iptables package which is required for firewall management 