### PR TITLE
nemos-images-reference-lunar: x86, aarch64: do not remove dmsetup

### DIFF
--- a/nemos-images-reference-lunar/aarch64/pre_disk_sync.sh
+++ b/nemos-images-reference-lunar/aarch64/pre_disk_sync.sh
@@ -19,7 +19,6 @@ for package in \
     linux-firmware \
     coreutils \
     tar \
-    dmsetup \
     cpio \
     dracut \
     dracut-core \

--- a/nemos-images-reference-lunar/x86/pre_disk_sync.sh
+++ b/nemos-images-reference-lunar/x86/pre_disk_sync.sh
@@ -19,7 +19,6 @@ for package in \
     linux-firmware \
     coreutils \
     tar \
-    dmsetup \
     cpio \
     dracut \
     dracut-core \


### PR DESCRIPTION
`dmsetup` is a useful tool for managing and querying the status of the device mappings running on the system (`dm-verity`, `dm-crypt`, and `dm-integrity`). We should keep this tool in the image.