### PR TITLE
nemos-images-reference-lunar: aarch64, x86: adjust pbkdf parameters

### DIFF
--- a/nemos-images-reference-lunar/aarch64/appliance.kiwi
+++ b/nemos-images-reference-lunar/aarch64/appliance.kiwi
@@ -38,8 +38,11 @@
                 <option name="--cipher" value="aes-gcm-random"/>
                 <!-- Include transparent dm-integrity support -->
                 <option name="--integrity" value="aead"/>
-                <!-- Enable pbkdf2 key derivation instead of using the default Argon, which causes OOM errors due to the small VM memory -->
-                <option name="--pbkdf" value="pbkdf2"/>
+                <!-- Adjust pbkdf parameters as the defaults cause OOM errors due to the small VM memory -->
+                <option name="--pbkdf" value="argon2id"/>
+                <option name="--pbkdf-memory" value="178155"/>
+                <option name="--pbkdf-force-iterations" value="4"/>
+                <option name="--pbkdf-parallel" value="2"/>
               </luksformat>
         </type>
     </preferences>

--- a/nemos-images-reference-lunar/x86/appliance.kiwi
+++ b/nemos-images-reference-lunar/x86/appliance.kiwi
@@ -38,8 +38,11 @@
                 <option name="--cipher" value="aes-gcm-random"/>
                 <!-- Include transparent dm-integrity support -->
                 <option name="--integrity" value="aead"/>
-                <!-- Enable pbkdf2 key derivation instead of using the default Argon, which causes OOM errors due to the small VM memory -->
-                <option name="--pbkdf" value="pbkdf2"/>
+                <!-- Adjust pbkdf parameters as the defaults cause OOM errors due to the small VM memory -->
+                <option name="--pbkdf" value="argon2id"/>
+                <option name="--pbkdf-memory" value="178155"/>
+                <option name="--pbkdf-force-iterations" value="4"/>
+                <option name="--pbkdf-parallel" value="2"/>
               </luksformat>
         </type>
     </preferences>


### PR DESCRIPTION
pbkdf2 is considered much less secure than the default argon2id, and it was only selected because the default argon2id settings can cause out-of-memory errors on small systems. This can however be worked around by manually setting the argon2id parameters to require less memory, while still making use of the much more secure pbkdf scheme.