### PR TITLE
nemos-images-embedded-lunar: disable runtime check for dracut-kiwi-overlay

### DIFF
--- a/nemos-images-embedded-lunar/kiwi.yaml
+++ b/nemos-images-embedded-lunar/kiwi.yaml
@@ -1,4 +1,8 @@
 ---
 # SPDX-License-Identifier: GPL-2.0-or-later
+runtime_checks:
+  - disable:
+      - "check_dracut_module_for_disk_overlay_in_package_list"
+
 mapper:
   - part_mapper: kpartx


### PR DESCRIPTION
This brings the configuration more in line with the configration for nemos-images-reference-lunar, and allows building without an additional external configuration file.