### PR TITLE
.github: workflows: add actions to build NemOS images

### DIFF
--- a/.github/workflows/debian-packages.yaml
+++ b/.github/workflows/debian-packages.yaml
@@ -1,7 +1,6 @@
 ---
 name: Debian Packages
 on: 
-  push: {}
   pull_request: {}
 jobs:
   Create-Debian-Packages:

--- a/.github/workflows/nemos-images-minimal-lunar.yaml
+++ b/.github/workflows/nemos-images-minimal-lunar.yaml
@@ -1,0 +1,28 @@
+---
+name: nemos-images-minimal-lunar
+on:
+  pull_request: {}
+jobs:
+  qemu-amd64:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+      - name: "Update system packages"
+        run: |
+          sudo apt update
+          sudo apt full-upgrade -y
+      - name: "Setup Kiwi PPA"
+        run: |
+          sudo apt install -y software-properties-common
+          sudo add-apt-repository -y ppa:nemos-team/kiwi
+      - name: "Install Kiwi"
+        run: |
+          sudo apt install -y kiwi kiwi-systemdeps
+      - name: "Run Kiwi"
+        run: |
+          sudo kiwi-ng --debug --profile bootstrapped \
+            --config nemos-images-minimal-lunar/kiwi.yaml \
+            system build \
+            --description nemos-images-minimal-lunar/qemu-amd64/ \
+            --target-dir build

--- a/.github/workflows/nemos-images-reference-lunar.yaml
+++ b/.github/workflows/nemos-images-reference-lunar.yaml
@@ -1,0 +1,28 @@
+---
+name: nemos-images-reference-lunar
+on:
+  pull_request: {}
+jobs:
+  qemu-amd64:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+      - name: "Update system packages"
+        run: |
+          sudo apt update
+          sudo apt full-upgrade -y
+      - name: "Setup Kiwi PPA"
+        run: |
+          sudo apt install -y software-properties-common
+          sudo add-apt-repository -y ppa:nemos-team/kiwi
+      - name: "Install Kiwi"
+        run: |
+          sudo apt install -y kiwi kiwi-systemdeps
+      - name: "Run Kiwi"
+        run: |
+          sudo kiwi-ng --debug --profile bootstrapped \
+            --config nemos-images-reference-lunar/kiwi.yaml \
+            system build \
+            --description nemos-images-reference-lunar/qemu-amd64/ \
+            --target-dir build


### PR DESCRIPTION
Both minimal and reference images are now automatically built on pull requests.

This uses the NemOS Kiwi PPA to provide Kiwi for Ubuntu 22.04.