### PR TITLE
Add integration tests using the spread framework

### DIFF
--- a/.github/workflows/debian-packages.yaml
+++ b/.github/workflows/debian-packages.yaml
@@ -1,10 +1,10 @@
 ---
-name: Debian Packages
-on: 
+name: "Debian Packages"
+on:
   pull_request: {}
 jobs:
   Create-Debian-Packages:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"

--- a/.github/workflows/debian-packages.yaml
+++ b/.github/workflows/debian-packages.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Install dependencies"
         run: "sudo apt update && sudo apt full-upgrade -y && sudo apt install -y devscripts equivs build-essential"
       - name: "Install additional package build dependencies"

--- a/.github/workflows/nemos-images-minimal-lunar.yaml
+++ b/.github/workflows/nemos-images-minimal-lunar.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: "ubuntu-22.04"
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Update system packages"
         run: |
           sudo apt update
@@ -28,3 +28,40 @@ jobs:
             system build \
             --description nemos-images-minimal-lunar/qemu-amd64/ \
             --target-dir build
+          sudo mv build/nemos-image-minimal-lunar.*.qcow2 \
+            nemos-image-minimal-lunar.qcow2
+      - name: "Archive"
+        uses: "actions/upload-artifact@v3"
+        with:
+          name: "nemos-images-minimal-lunar"
+          path: |
+            nemos-image-minimal-lunar.qcow2
+  spread:
+    runs-on: "ubuntu-22.04"
+    needs: "qemu-amd64"
+    steps:
+      - uses: "actions/checkout@v3"
+      - name: "Update system packages"
+        run: |
+          sudo apt update
+          sudo DEBIAN_FRONTEND="noninteractive" \
+            apt full-upgrade -y
+      - name: "Install dependencies"
+        run: |
+          sudo DEBIAN_FRONTEND="noninteractive" \
+            apt install -y golang ovmf qemu-system-x86
+      - name: "Install spread"
+        run: |
+          go clean -modcache
+          go install github.com/snapcore/spread/cmd/spread@latest
+      - name: "Download QEMU image"
+        uses: actions/download-artifact@v3
+        with:
+          name: "nemos-images-minimal-lunar"
+      - name: "Copy QEMU image to spread directory"
+        run: |
+          mkdir -p ~/.spread/adhoc
+          mv nemos-image-minimal-lunar.qcow2 ~/.spread/adhoc/
+      - name: "Run the spread tests inside QEMU"
+        run: |
+          ~/go/bin/spread -v adhoc:nemos-image-minimal-lunar

--- a/.github/workflows/nemos-images-minimal-lunar.yaml
+++ b/.github/workflows/nemos-images-minimal-lunar.yaml
@@ -4,21 +4,23 @@ on:
   pull_request: {}
 jobs:
   qemu-amd64:
-    runs-on: ubuntu-22.04
+    runs-on: "ubuntu-22.04"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
       - name: "Update system packages"
         run: |
           sudo apt update
-          sudo apt full-upgrade -y
+          sudo DEBIAN_FRONTEND="noninteractive" \
+            apt full-upgrade -y
       - name: "Setup Kiwi PPA"
         run: |
           sudo apt install -y software-properties-common
           sudo add-apt-repository -y ppa:nemos-team/kiwi
       - name: "Install Kiwi"
         run: |
-          sudo apt install -y kiwi kiwi-systemdeps
+          sudo DEBIAN_FRONTEND="noninteractive" \
+            apt install -y kiwi kiwi-systemdeps
       - name: "Run Kiwi"
         run: |
           sudo kiwi-ng --debug --profile bootstrapped \

--- a/.github/workflows/nemos-images-reference-lunar.yaml
+++ b/.github/workflows/nemos-images-reference-lunar.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: "ubuntu-22.04"
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Update system packages"
         run: |
           sudo apt update
@@ -23,8 +23,45 @@ jobs:
             apt install -y kiwi kiwi-systemdeps
       - name: "Run Kiwi"
         run: |
-          sudo kiwi-ng --debug --profile bootstrapped \
+          sudo kiwi-ng --debug --profile development \
             --config nemos-images-reference-lunar/kiwi.yaml \
             system build \
             --description nemos-images-reference-lunar/qemu-amd64/ \
             --target-dir build
+          sudo mv build/nemos-image-reference-lunar.*.qcow2 \
+            nemos-image-reference-lunar.qcow2
+      - name: "Archive"
+        uses: "actions/upload-artifact@v3"
+        with:
+          name: "nemos-images-reference-lunar"
+          path: |
+            nemos-image-reference-lunar.qcow2
+  spread:
+    runs-on: "ubuntu-22.04"
+    needs: "qemu-amd64"
+    steps:
+      - uses: "actions/checkout@v3"
+      - name: "Update system packages"
+        run: |
+          sudo apt update
+          sudo DEBIAN_FRONTEND="noninteractive" \
+            apt full-upgrade -y
+      - name: "Install dependencies"
+        run: |
+          sudo DEBIAN_FRONTEND="noninteractive" \
+            apt install -y golang ovmf qemu-system-x86
+      - name: "Install spread"
+        run: |
+          go clean -modcache
+          go install github.com/snapcore/spread/cmd/spread@latest
+      - name: "Download QEMU image"
+        uses: actions/download-artifact@v3
+        with:
+          name: "nemos-images-reference-lunar"
+      - name: "Copy QEMU image to spread directory"
+        run: |
+          mkdir -p ~/.spread/adhoc
+          mv nemos-image-reference-lunar.qcow2 ~/.spread/adhoc/
+      - name: "Run the spread tests inside QEMU"
+        run: |
+          ~/go/bin/spread -v adhoc:nemos-image-reference-lunar

--- a/.github/workflows/nemos-images-reference-lunar.yaml
+++ b/.github/workflows/nemos-images-reference-lunar.yaml
@@ -4,21 +4,23 @@ on:
   pull_request: {}
 jobs:
   qemu-amd64:
-    runs-on: ubuntu-22.04
+    runs-on: "ubuntu-22.04"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
       - name: "Update system packages"
         run: |
           sudo apt update
-          sudo apt full-upgrade -y
+          sudo DEBIAN_FRONTEND="noninteractive" \
+            apt full-upgrade -y
       - name: "Setup Kiwi PPA"
         run: |
           sudo apt install -y software-properties-common
           sudo add-apt-repository -y ppa:nemos-team/kiwi
       - name: "Install Kiwi"
         run: |
-          sudo apt install -y kiwi kiwi-systemdeps
+          sudo DEBIAN_FRONTEND="noninteractive" \
+            apt install -y kiwi kiwi-systemdeps
       - name: "Run Kiwi"
         run: |
           sudo kiwi-ng --debug --profile bootstrapped \

--- a/nemos-images-minimal-lunar/qemu-amd64/pre_disk_sync.sh
+++ b/nemos-images-minimal-lunar/qemu-amd64/pre_disk_sync.sh
@@ -34,7 +34,6 @@ for package in \
     dirmngr \
     gpgconf \
     gpg \
-    bash \
     findutils \
     sed \
     grep \

--- a/nemos-images-minimal-lunar/qemu-arm64/pre_disk_sync.sh
+++ b/nemos-images-minimal-lunar/qemu-arm64/pre_disk_sync.sh
@@ -56,7 +56,6 @@ for package in \
     dirmngr \
     gpgconf \
     gpg \
-    bash \
     findutils \
     sed \
     grep \

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,45 @@
+---
+
+project: nemos-images
+
+path: /tmp/nemos
+
+backends:
+  adhoc:
+    allocate: |
+      VM_IMAGE="${HOME}/.spread/${SPREAD_BACKEND}/${SPREAD_SYSTEM}.qcow2"
+      NVRAM="/tmp/${SPREAD_BACKEND}-${SPREAD_SYSTEM}.fd"
+
+      if [ ! -f "${VM_IMAGE}" ]; then
+        FATAL "File not found: ${VM_IMAGE}"
+      fi
+
+      SSH_PORT=$((30000 + $RANDOM % 20000))
+
+      cp /usr/share/OVMF/OVMF_VARS.fd ${NVRAM}
+
+      qemu-system-x86_64 -M q35 -m 1G -daemonize \
+        -drive file="/usr/share/OVMF/OVMF_CODE.fd",readonly=on,if=pflash,format=raw,unit=0 \
+        -drive file="${NVRAM}",if=pflash,format=raw,unit=1 \
+        -drive file="${VM_IMAGE}",format=qcow2,if=virtio \
+        -netdev user,id=user0,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22 \
+        -device netdev=user0,driver=virtio-net-pci \
+        -serial null -parallel null -monitor none -display none -vga none \
+        -pidfile /tmp/${SPREAD_BACKEND}-${SPREAD_SYSTEM}.pid
+
+      sleep 30
+      ADDRESS 127.0.0.1:${SSH_PORT}
+    discard: |
+      kill -9 $(cat /tmp/${SPREAD_BACKEND}-${SPREAD_SYSTEM}.pid)
+      rm -f /tmp/${SPREAD_BACKEND}-${SPREAD_SYSTEM}.{fd,pid}
+    systems:
+      - nemos-image-reference-lunar:
+          username: admin
+          password: linux
+      - nemos-image-minimal-lunar:
+          username: admin
+          password: linux
+
+suites:
+  tests/spread/:
+    summary: Integration tests

--- a/tests/spread/os-information-23.04/task.yaml
+++ b/tests/spread/os-information-23.04/task.yaml
@@ -1,0 +1,12 @@
+---
+
+summary: "Verify Ubuntu 23.04 OS release information"
+
+systems:
+  - "nemos-image-*-lunar"
+
+execute: |
+  . /etc/os-release
+  test "${NAME}" = "Ubuntu"
+  test "${VERSION_ID}" = "23.04"
+  test "${VERSION_CODENAME}" = "lunar"

--- a/tests/spread/storage-configuration/task.yaml
+++ b/tests/spread/storage-configuration/task.yaml
@@ -1,0 +1,33 @@
+---
+
+summary: "Verify storage configuration"
+
+systems:
+  - "nemos-image-reference-*"
+
+execute: |
+  # Check that the dm-crypt parameters are correct
+  test $(dmsetup status luks | awk '{ print $3;}') = "crypt"
+  export LUKS="$(cryptsetup status luks)"
+  test $(echo "${LUKS}" | awk '{ if ($1 == "type:") print $2;}') = "LUKS2"
+  test $(echo "${LUKS}" | awk '{ if ($1 == "cipher:") print $2;}') = "aegis128-random"
+  test $(echo "${LUKS}" | awk '{ if ($1 == "integrity:") print $2;}') = "aead"
+  test $(echo "${LUKS}" | awk '{ if ($1 == "mode:") print $2;}') = "read/write"
+
+  # Check that the dm-integrity parameters are correct
+  test $(dmsetup status luks_dif | awk '{ print $3;}') = "integrity"
+  test $(cryptsetup status luks_dif | grep type | awk '{ print $2;}') = "INTEGRITY"
+  export INTEGRITY="$(integritysetup status luks_dif)"
+  test $(echo "${INTEGRITY}" | awk '{ if ($1 == "type:") print $2;}') = "INTEGRITY"
+  test $(echo "${INTEGRITY}" | awk '{ if ($1 == "failures:") print $2;}') = "0"
+  test $(echo "${INTEGRITY}" | awk '{ if ($1 == "mode:") print $2;}') = "read/write"
+
+  # Check that the dm-verity parameters are correct
+  test $(dmsetup status verityRoot | awk '{ print $3;}') = "verity"
+  export VERITY="$(veritysetup status verityRoot)"
+  test $(echo "${VERITY}" | awk '{ if ($1 == "type:") print $2;}') = "VERITY"
+  test $(echo "${VERITY}" | awk '{ if ($1 == "status:") print $2;}') = "verified"
+  test $(echo "${VERITY}" | awk '{ if ($1 == "mode:") print $2;}') = "readonly"
+
+  # Check that / is using overlayfs
+  test $(mount | grep "on / " | awk '{ print $1;}') = "overlay"


### PR DESCRIPTION
This changeset adds the required files for running tests inside generated VM images using the spread framework (https://github.com/snapcore/spread).

Spread tests can be run by running the following commands (the build directory refers to the location where the Kiwi images were built):

```
mkdir -p ~/.spread/qemu
cp build/nemos-image-minimal-lunar.x86_64-1.0.1.qcow2 \
    ~/.spread/qemu/nemos-image-minimal-lunar.img
cp build/nemos-image-reference-lunar.x86_64-1.0.1.qcow2 \
    ~/.spread/qemu/nemos-image-reference-lunar.img
spread -v
```

These tests can be used to automatically verify that features are present and enabled in the generated images.