### PR TITLE
nemos-images-{minimal,reference}-lunar: qemu-{amd64,arm64}: use linux-s32

### DIFF
--- a/nemos-images-minimal-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-minimal-lunar/qemu-amd64/appliance.kiwi
@@ -35,8 +35,11 @@
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/admin" name="admin" groups="users" shell="/bin/ash"/>
     </users>
 
-    <repository type="apt-deb" alias="Lunar-Bootstrap-PPA" distribution="lunar" components="main" repository_gpgcheck="false" profiles="bootstrapped">
+    <repository type="apt-deb" alias="NemOS-Bootstrap-PPA" distribution="lunar" components="main" repository_gpgcheck="false" profiles="bootstrapped">
         <source path="https://ppa.launchpadcontent.net/nemos-team/bootstrap/ubuntu"/>
+    </repository>
+    <repository type="apt-deb" alias="NemOS-PPA" distribution="lunar" components="main" repository_gpgcheck="false">
+        <source path="https://ppa.launchpadcontent.net/nemos-team/ppa/ubuntu" />
     </repository>
     <repository type="apt-deb" alias="Lunar-security" distribution="lunar-security" components="main multiverse restricted universe" repository_gpgcheck="false">
         <source path="http://security.ubuntu.com/ubuntu"/>
@@ -50,7 +53,7 @@
 
     <packages type="image">
         <!-- kernel -->
-        <package name="linux-generic"/>
+        <package name="linux-s32"/>
         <!-- network, ssh, sudo -->
         <package name="openssh-client"/>
         <package name="openssh-server"/>

--- a/nemos-images-minimal-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-minimal-lunar/qemu-amd64/appliance.kiwi
@@ -77,8 +77,12 @@
         <package name="kiwi-dracut-overlay"/>
     </packages>
 
-    <packages type="bootstrap" bootstrap_package="kiwi-bootstrap-lunar" profiles="bootstrapped"/>
+    <packages type="bootstrap" bootstrap_package="kiwi-bootstrap-lunar" profiles="bootstrapped">
+        <package name="ca-certificates" />
+        <package name="apt-transport-https" />
+    </packages>
     <packages type="bootstrap" profiles="default">
-        <package name="usrmerge"/>
+        <package name="ca-certificates" />
+        <package name="apt-transport-https" />
     </packages>
 </image>

--- a/nemos-images-minimal-lunar/qemu-amd64/pre_disk_sync.sh
+++ b/nemos-images-minimal-lunar/qemu-amd64/pre_disk_sync.sh
@@ -6,7 +6,7 @@ set -ex
 #=======================================
 # Create initrd link
 #---------------------------------------
-ln -s /boot/initrd-*-generic /boot/initrd
+ln -s /boot/initrd-*-s32 /boot/initrd
 
 #=======================================
 # Force delete packages not needed/wanted
@@ -14,7 +14,7 @@ ln -s /boot/initrd-*-generic /boot/initrd
 for package in \
     $(apt list --installed | grep ^linux-headers | cut -f 1 -d/) \
     $(apt list --installed | grep ^linux-modules | cut -f 1 -d/) \
-    linux-image-generic \
+    linux-image-s32 \
     linux-firmware \
     coreutils \
     tar \

--- a/nemos-images-minimal-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-minimal-lunar/qemu-arm64/appliance.kiwi
@@ -35,8 +35,11 @@
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/admin" name="admin" groups="users" shell="/bin/ash"/>
     </users>
 
-    <repository type="apt-deb" alias="Lunar-Bootstrap-PPA" distribution="lunar" components="main" repository_gpgcheck="false" profiles="bootstrapped">
+    <repository type="apt-deb" alias="NemOS-Bootstrap-PPA" distribution="lunar" components="main" repository_gpgcheck="false" profiles="bootstrapped">
         <source path="https://ppa.launchpadcontent.net/nemos-team/bootstrap/ubuntu"/>
+    </repository>
+    <repository type="apt-deb" alias="NemOS-PPA" distribution="lunar" components="main" repository_gpgcheck="false">
+        <source path="https://ppa.launchpadcontent.net/nemos-team/ppa/ubuntu" />
     </repository>
     <repository type="apt-deb" alias="Lunar-security" distribution="lunar-security" components="main multiverse restricted universe" repository_gpgcheck="false">
         <source path="http://ports.ubuntu.com/"/>
@@ -50,7 +53,7 @@
 
     <packages type="image">
         <!-- kernel -->
-        <package name="linux-generic"/>
+        <package name="linux-s32"/>
         <!-- network, ssh, sudo -->
         <package name="openssh-client"/>
         <package name="openssh-server"/>

--- a/nemos-images-minimal-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-minimal-lunar/qemu-arm64/appliance.kiwi
@@ -78,8 +78,12 @@
         <package name="kiwi-dracut-overlay"/>
     </packages>
 
-    <packages type="bootstrap" bootstrap_package="kiwi-bootstrap-lunar" profiles="bootstrapped"/>
+    <packages type="bootstrap" bootstrap_package="kiwi-bootstrap-lunar" profiles="bootstrapped">
+        <package name="ca-certificates" />
+        <package name="apt-transport-https" />
+    </packages>
     <packages type="bootstrap" profiles="default">
-        <package name="usrmerge"/>
+        <package name="ca-certificates" />
+        <package name="apt-transport-https" />
     </packages>
 </image>

--- a/nemos-images-minimal-lunar/qemu-arm64/pre_disk_sync.sh
+++ b/nemos-images-minimal-lunar/qemu-arm64/pre_disk_sync.sh
@@ -36,7 +36,7 @@ rm /boot/qemu.dtb
 for package in \
     $(apt list --installed | grep ^linux-headers | cut -f 1 -d/) \
     $(apt list --installed | grep ^linux-modules | cut -f 1 -d/) \
-    linux-image-generic \
+    linux-image-s32 \
     linux-firmware \
     coreutils \
     tar \

--- a/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
@@ -79,7 +79,7 @@
 
     <packages type="image">
         <!-- kernel -->
-        <package name="linux-generic" />
+        <package name="linux-s32"/>
         <!-- Base packages -->
         <package name="usrmerge" />
         <package name="netbase" />

--- a/nemos-images-reference-lunar/qemu-amd64/pre_disk_sync.sh
+++ b/nemos-images-reference-lunar/qemu-amd64/pre_disk_sync.sh
@@ -6,7 +6,7 @@ set -ex
 #=======================================
 # Create initrd link
 #---------------------------------------
-ln -s /boot/initrd-*-generic /boot/initrd
+ln -s /boot/initrd-*-s32 /boot/initrd
 
 #=======================================
 # Force delete packages not needed/wanted
@@ -14,8 +14,8 @@ ln -s /boot/initrd-*-generic /boot/initrd
 for package in \
     $(apt list --installed | grep ^linux-headers | cut -f 1 -d/) \
     $(apt list --installed | grep ^linux-modules-extra | cut -f 1 -d/) \
-    linux-image-generic \
-    linux-generic \
+    linux-image-s32 \
+    linux-s32 \
     linux-firmware \
     coreutils \
     tar \

--- a/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
@@ -79,7 +79,7 @@
 
     <packages type="image">
         <!-- kernel -->
-        <package name="linux-generic" />
+        <package name="linux-s32"/>
         <!-- Base packages -->
         <package name="usrmerge" />
         <package name="netbase" />

--- a/nemos-images-reference-lunar/qemu-arm64/pre_disk_sync.sh
+++ b/nemos-images-reference-lunar/qemu-arm64/pre_disk_sync.sh
@@ -6,7 +6,7 @@ set -ex
 #=======================================
 # Create initrd link
 #---------------------------------------
-ln -s /boot/initrd-*-generic /boot/initrd
+ln -s /boot/initrd-*-s32 /boot/initrd
 
 #=======================================
 # Force delete packages not needed/wanted
@@ -14,8 +14,8 @@ ln -s /boot/initrd-*-generic /boot/initrd
 for package in \
     $(apt list --installed | grep ^linux-headers | cut -f 1 -d/) \
     $(apt list --installed | grep ^linux-modules-extra | cut -f 1 -d/) \
-    linux-image-generic \
-    linux-generic \
+    linux-image-s32 \
+    linux-s32 \
     linux-firmware \
     coreutils \
     tar \


### PR DESCRIPTION
Instead of using the standard linux-generic kernel, we can use the new tailor-made linux-s32 kernel from the NemOS PPA for building the images. This kernel is smaller and has specific configuration options which are helpful for NemOS development.