### PR TITLE
nemos-images-reference-lunar: preseed snaps in the development images

### DIFF
--- a/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
@@ -19,7 +19,7 @@
         <packagemanager>apt</packagemanager>
         <type image="oem" filesystem="xfs" firmware="efi" initrd_system="dracut"
             overlayroot="true" overlayroot_write_partition="true"
-            overlayroot_readonly_partsize="256" squashfscompression="zstd"
+            overlayroot_readonly_partsize="1024" squashfscompression="zstd"
             bootpartition="true" bootpartsize="256" bootfilesystem="ext4" format="qcow2"
             kernelcmdline="console=ttyS0 rd.systemd.verity=1 root=/dev/mapper/verityRoot verityroot=/dev/disk/by-partlabel/p.lxreadonly overlay=/dev/mapper/luks rd.luks=yes"
             verity_blocks="all" embed_verity_metadata="true" luks_version="luks2" luks="insecure">
@@ -27,7 +27,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <size unit="G">2</size>
+            <size unit="G">3</size>
             <partitions>
                 <partition name="home" size="10" mountpoint="/home" filesystem="ext4" />
                 <partition name="oci-storage" size="512" mountpoint="/var/lib/containers/storage" filesystem="xfs" />
@@ -125,6 +125,15 @@
         <!-- snaps -->
         <package name="snapd" />
         <package name="xdelta3" />
+        <!-- testing tools for checkbox -->
+        <package name="fwts" />
+        <package name="stress-ng" />
+        <package name="ipmitool" />
+        <package name="dmidecode" />
+        <package name="sosreport" />
+        <package name="apport" />
+        <package name="dkms" />
+        <package name="mokutil" />
     </packages>
 
     <!-- Bootstrap configuration -->

--- a/nemos-images-reference-lunar/qemu-amd64/config.sh
+++ b/nemos-images-reference-lunar/qemu-amd64/config.sh
@@ -4,6 +4,7 @@
 # Functions...
 #--------------------------------------
 test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
 
 set -ex
 
@@ -62,3 +63,46 @@ done
 #--------------------------------------
 baseInsertService ssh
 baseInsertService systemd-networkd
+
+#======================================
+# Install snaps when building with the development profile
+#--------------------------------------
+
+# The list of profiles is comma separated; change them to spaces to iterate
+# over them.
+for profile in ${kiwi_profiles//,/ }; do
+    if [ "${profile}" = "development" ]; then
+        # Use the preseeding feature of snapd to preload some snaps into the
+        # system. This will download the snaps from the global Snap Store, copy
+        # them to the snapd seed directory, and add each to the preseed YAML
+        # file to instruct snapd to install them on first boot.
+        # This requires network access to the Snap Store in Kiwi.
+        mkdir -p /var/lib/snapd/seed
+        echo "snaps": > /var/lib/snapd/seed/seed.yaml
+        for snap in snapd checkbox22 checkbox core22; do
+            snap download $snap
+            # Add this new snap to the list of seeded snaps
+            cat >> /var/lib/snapd/seed/seed.yaml << EOF
+  - name: ${snap}
+    channel: latest/stable
+    file: $(ls ${snap}_*.snap)
+EOF
+            # Checkbox snap requires classic confinement mode
+            if [ "${snap}" = "checkbox" ]; then
+                cat >> /var/lib/snapd/seed/seed.yaml << EOF
+    classic: true
+EOF
+            fi
+        done
+
+        # Copy the snap archives
+        install -Dm0644 *.snap -t /var/lib/snapd/seed/snaps/
+        # Copy the snap assertions (cryptographic signatures)
+        install -Dm0644 *.assert -t /var/lib/snapd/seed/assertions/
+
+        # Install the generic snapd model assertion so that the snaps can
+        # be verified and snapd properly initialised.
+        snap known --remote model series=16 brand-id=generic \
+            model=generic-classic > /var/lib/snapd/seed/assertions/model
+    fi
+done

--- a/nemos-images-reference-lunar/qemu-amd64/pre_disk_sync.sh
+++ b/nemos-images-reference-lunar/qemu-amd64/pre_disk_sync.sh
@@ -44,13 +44,11 @@ for package in \
     libksba8 \
     libgmp10 \
     libgnutls30 \
-    libstdc++6 \
     apt \
     python3 \
     python3.10 \
     python3-minimal \
     python3.10-minimal \
-    perl-base \
     debianutils
 do
     rm -f /var/lib/dpkg/info/${package}*.pre*

--- a/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
@@ -19,7 +19,7 @@
         <packagemanager>apt</packagemanager>
         <type image="oem" filesystem="xfs" firmware="efi" initrd_system="dracut"
             overlayroot="true" overlayroot_write_partition="true"
-            overlayroot_readonly_partsize="256" squashfscompression="zstd"
+            overlayroot_readonly_partsize="1024" squashfscompression="zstd"
             bootpartition="true" bootpartsize="256" bootfilesystem="ext4" format="qcow2"
             kernelcmdline="console=ttyS0 rd.systemd.verity=1 root=/dev/mapper/verityRoot verityroot=/dev/disk/by-partlabel/p.lxreadonly overlay=/dev/mapper/luks rd.luks=yes"
             verity_blocks="all" embed_verity_metadata="true" luks_version="luks2" luks="insecure">
@@ -27,7 +27,7 @@
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
-            <size unit="G">2</size>
+            <size unit="G">3</size>
             <partitions>
                 <partition name="home" size="10" mountpoint="/home" filesystem="ext4" />
                 <partition name="oci-storage" size="512" mountpoint="/var/lib/containers/storage" filesystem="xfs" />
@@ -125,6 +125,15 @@
         <!-- snaps -->
         <package name="snapd" />
         <package name="xdelta3" />
+        <!-- testing tools for checkbox -->
+        <package name="fwts" />
+        <package name="stress-ng" />
+        <package name="ipmitool" />
+        <package name="dmidecode" />
+        <package name="sosreport" />
+        <package name="apport" />
+        <package name="dkms" />
+        <package name="mokutil" />
     </packages>
 
     <!-- Bootstrap configuration -->

--- a/nemos-images-reference-lunar/qemu-arm64/config.sh
+++ b/nemos-images-reference-lunar/qemu-arm64/config.sh
@@ -62,3 +62,46 @@ done
 #--------------------------------------
 baseInsertService ssh
 baseInsertService systemd-networkd
+
+#======================================
+# Install snaps when building with the development profile
+#--------------------------------------
+
+# The list of profiles is comma separated; change them to spaces to iterate
+# over them.
+for profile in ${kiwi_profiles//,/ }; do
+    if [ "${profile}" = "development" ]; then
+        # Use the preseeding feature of snapd to preload some snaps into the
+        # system. This will download the snaps from the global Snap Store, copy
+        # them to the snapd seed directory, and add each to the preseed YAML
+        # file to instruct snapd to install them on first boot.
+        # This requires network access to the Snap Store in Kiwi.
+        mkdir -p /var/lib/snapd/seed
+        echo "snaps": > /var/lib/snapd/seed/seed.yaml
+        for snap in snapd checkbox22 checkbox core22; do
+            snap download $snap
+            # Add this new snap to the list of seeded snaps
+            cat >> /var/lib/snapd/seed/seed.yaml << EOF
+  - name: ${snap}
+    channel: latest/stable
+    file: $(ls ${snap}_*.snap)
+EOF
+            # Checkbox snap requires classic confinement mode
+            if [ "${snap}" = "checkbox" ]; then
+                cat >> /var/lib/snapd/seed/seed.yaml << EOF
+    classic: true
+EOF
+            fi
+        done
+
+        # Copy the snap archives
+        install -Dm0644 *.snap -t /var/lib/snapd/seed/snaps/
+        # Copy the snap assertions (cryptographic signatures)
+        install -Dm0644 *.assert -t /var/lib/snapd/seed/assertions/
+
+        # Install the generic snapd model assertion so that the snaps can
+        # be verified and snapd properly initialised.
+        snap known --remote model series=16 brand-id=generic \
+            model=generic-classic > /var/lib/snapd/seed/assertions/model
+    fi
+done

--- a/nemos-images-reference-lunar/qemu-arm64/pre_disk_sync.sh
+++ b/nemos-images-reference-lunar/qemu-arm64/pre_disk_sync.sh
@@ -44,13 +44,11 @@ for package in \
     libksba8 \
     libgmp10 \
     libgnutls30 \
-    libstdc++6 \
     apt \
     python3 \
     python3.10 \
     python3-minimal \
     python3.10-minimal \
-    perl-base \
     debianutils
 do
     rm -f /var/lib/dpkg/info/${package}*.pre*


### PR DESCRIPTION
This change adds the checkbox and checkbox22 snaps to the reference images built with the "development" profile. These snaps provide the checkbox framework, which provides an automatic test suite inside the resulting image. It also installs some additional tools which are needed for the checkbox tests.

The snaps are installed using the preseeding functionality of snapd. The snap files are downloaded during the Kiwi build process, so network access to the Snap Store is required when building with the development profile.

Due to the large size of the snap files, the partition sizes need to be increased to accomodate the new tools and snaps.