### PR TITLE
nemos-images-reference-lunar: do not remove bash and python3

### DIFF
--- a/nemos-images-reference-lunar/qemu-amd64/pre_disk_sync.sh
+++ b/nemos-images-reference-lunar/qemu-amd64/pre_disk_sync.sh
@@ -34,7 +34,6 @@ for package in \
     dirmngr \
     gpgconf \
     gpg \
-    bash \
     findutils \
     sed \
     grep \
@@ -45,10 +44,6 @@ for package in \
     libgmp10 \
     libgnutls30 \
     apt \
-    python3 \
-    python3.10 \
-    python3-minimal \
-    python3.10-minimal \
     debianutils
 do
     rm -f /var/lib/dpkg/info/${package}*.pre*

--- a/nemos-images-reference-lunar/qemu-arm64/pre_disk_sync.sh
+++ b/nemos-images-reference-lunar/qemu-arm64/pre_disk_sync.sh
@@ -34,7 +34,6 @@ for package in \
     dirmngr \
     gpgconf \
     gpg \
-    bash \
     findutils \
     sed \
     grep \
@@ -45,10 +44,6 @@ for package in \
     libgmp10 \
     libgnutls30 \
     apt \
-    python3 \
-    python3.10 \
-    python3-minimal \
-    python3.10-minimal \
     debianutils
 do
     rm -f /var/lib/dpkg/info/${package}*.pre*


### PR DESCRIPTION
These packages are required for running the checkbox snap, so we should not remove them in the development profile.