### PR TITLE
nemos-images-reference-lunar: qemu-{amd64,arm64}: add tuptime package

### DIFF
--- a/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
@@ -87,6 +87,7 @@
         <package name="cron" />
         <package name="xz-utils" />
         <package name="zstd" />
+        <package name="tuptime" />
         <!-- bootloader -->
         <package name="grub-common" arch="x86_64"/>
         <package name="grub2-common" arch="x86_64"/>

--- a/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
@@ -87,6 +87,7 @@
         <package name="cron" />
         <package name="xz-utils" />
         <package name="zstd" />
+        <package name="tuptime" />
         <!-- bootloader -->
         <package name="grub-common" />
         <package name="grub2-common" />


### PR DESCRIPTION
This package is used for tracking total system uptime.