### PR TITLE
nemos-images-reference-lunar: qemu-{arm64,amd64}: add polkitd

### DIFF
--- a/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
@@ -88,6 +88,7 @@
         <package name="xz-utils" />
         <package name="zstd" />
         <package name="tuptime" />
+        <package name="polkitd" />
         <!-- bootloader -->
         <package name="grub-common" arch="x86_64"/>
         <package name="grub2-common" arch="x86_64"/>

--- a/nemos-images-reference-lunar/qemu-amd64/root/etc/polkit-1/localauthority/10-vendor.d/admin-org.freedesktop.login1.pkla
+++ b/nemos-images-reference-lunar/qemu-amd64/root/etc/polkit-1/localauthority/10-vendor.d/admin-org.freedesktop.login1.pkla
@@ -1,0 +1,14 @@
+[Admin - Power off the system]
+Identity=unix-user:admin
+Action=org.freedesktop.login1.power-off
+ResultAny=yes
+
+[Admin - Reboot the system]
+Identity=unix-user:admin
+Action=org.freedesktop.login1.reboot
+ResultAny=yes
+
+[Admin - Halt the system]
+Identity=unix-user:admin
+Action=org.freedesktop.login1.halt
+ResultAny=yes

--- a/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
@@ -88,6 +88,7 @@
         <package name="xz-utils" />
         <package name="zstd" />
         <package name="tuptime" />
+        <package name="polkitd" />
         <!-- bootloader -->
         <package name="grub-common" />
         <package name="grub2-common" />

--- a/nemos-images-reference-lunar/qemu-arm64/root/polkit-1/localauthority/10-vendor.d/admin-org.freedesktop.login1.pkla
+++ b/nemos-images-reference-lunar/qemu-arm64/root/polkit-1/localauthority/10-vendor.d/admin-org.freedesktop.login1.pkla
@@ -1,0 +1,14 @@
+[Admin - Power off the system]
+Identity=unix-user:admin
+Action=org.freedesktop.login1.power-off
+ResultAny=yes
+
+[Admin - Reboot the system]
+Identity=unix-user:admin
+Action=org.freedesktop.login1.reboot
+ResultAny=yes
+
+[Admin - Halt the system]
+Identity=unix-user:admin
+Action=org.freedesktop.login1.halt
+ResultAny=yes


### PR DESCRIPTION
This adds the polkitd utility, which allows adding policies which determine what non-root users can do.

This also adds a default policy which allows the "admin" user to power-off, reboot, and halt the system using dbus access to logind.

This can be demonstrated by calling the following command as the admin user, which will shutdown the system:

    dbus-send --system --print-reply --dest=org.freedesktop.login1 \
        /org/freedesktop/login1 "org.freedesktop.login1.Manager.PowerOff" \
        boolean:true