### PR TITLE
Improve cleanup scripts

### DIFF
--- a/nemos-images-minimal-lunar/qemu-amd64/config.sh
+++ b/nemos-images-minimal-lunar/qemu-amd64/config.sh
@@ -7,11 +7,6 @@ test -f /.kconfig && . /.kconfig
 
 set -ex
 
-#======================================
-# Setup default target, multi-user
-#--------------------------------------
-baseSetRunlevel 3
-
 #==================================
 # Allow suid tools with busybox
 #----------------------------------
@@ -37,31 +32,7 @@ rm -rf /usr/lib/x86_64-linux-gnu/gconv
 #----------------------------------
 find /usr/share/doc/ ! -iname copyright -delete 2> /dev/null || true
 
-#==================================
-# Create init symlink
-#----------------------------------
-rm -f /sbin/init
-ln -rs /lib/systemd/systemd /sbin/init
-
-#==================================
-# Mask/Disable services
-#----------------------------------
-for service in \
-    apt-daily.service \
-    apt-daily.timer \
-    apt-daily-upgrade.service \
-    apt-daily-upgrade.timer \
-    grub-common.service \
-    grub-initrd-fallback.service \
-    systemd-resolved.service \
-    e2scrub_reap.service \
-    systemd-logind.service
-do
-    systemctl mask "${service}"
-done
-
 #======================================
 # Activate services
 #--------------------------------------
-baseInsertService ssh
 baseInsertService systemd-networkd

--- a/nemos-images-minimal-lunar/qemu-amd64/pre_disk_sync.sh
+++ b/nemos-images-minimal-lunar/qemu-amd64/pre_disk_sync.sh
@@ -104,3 +104,8 @@ ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
 #---------------------------------------
 rm -rf /var/cache/apt
 rm -rf /var/lib/apt/lists
+
+#=======================================
+# Make sure there are no source directories left behind
+#---------------------------------------
+rm -rf /usr/src

--- a/nemos-images-minimal-lunar/qemu-arm64/config.sh
+++ b/nemos-images-minimal-lunar/qemu-arm64/config.sh
@@ -8,11 +8,6 @@ test -f /.kconfig && . /.kconfig
 
 set -ex
 
-#======================================
-# Setup default target, multi-user
-#--------------------------------------
-baseSetRunlevel 3
-
 #==================================
 # Allow suid tools with busybox
 #----------------------------------
@@ -37,31 +32,7 @@ rm -rf /usr/share/i18n
 #----------------------------------
 find /usr/share/doc/ ! -iname copyright -delete 2> /dev/null || true
 
-#==================================
-# Create init symlink
-#----------------------------------
-rm -f /sbin/init
-ln -rs /lib/systemd/systemd /sbin/init
-
-#==================================
-# Mask/Disable services
-#----------------------------------
-for service in \
-    apt-daily.service \
-    apt-daily.timer \
-    apt-daily-upgrade.service \
-    apt-daily-upgrade.timer \
-    grub-common.service \
-    grub-initrd-fallback.service \
-    systemd-resolved.service \
-    e2scrub_reap.service \
-    systemd-logind.service
-do
-    systemctl mask "${service}"
-done
-
 #======================================
 # Activate services
 #--------------------------------------
-baseInsertService ssh
 baseInsertService systemd-networkd

--- a/nemos-images-minimal-lunar/qemu-arm64/pre_disk_sync.sh
+++ b/nemos-images-minimal-lunar/qemu-arm64/pre_disk_sync.sh
@@ -128,3 +128,8 @@ ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
 #---------------------------------------
 rm -rf /var/cache/apt
 rm -rf /var/lib/apt/lists
+
+#=======================================
+# Make sure there are no source directories left behind
+#---------------------------------------
+rm -rf /usr/src

--- a/nemos-images-reference-lunar/qemu-amd64/config.sh
+++ b/nemos-images-reference-lunar/qemu-amd64/config.sh
@@ -8,11 +8,6 @@ test -f /.profile && . /.profile
 
 set -ex
 
-#======================================
-# Setup default target, multi-user
-#--------------------------------------
-baseSetRunlevel 3
-
 #==================================
 # Allow suid tools with busybox
 #----------------------------------
@@ -37,31 +32,9 @@ rm -rf /usr/lib/x86_64-linux-gnu/gconv
 #----------------------------------
 find /usr/share/doc/ ! -iname copyright -delete 2> /dev/null || true
 
-#==================================
-# Create init symlink
-#----------------------------------
-rm -f /sbin/init
-ln -rs /lib/systemd/systemd /sbin/init
-
-#==================================
-# Mask/Disable services
-#----------------------------------
-for service in \
-    apt-daily.service \
-    apt-daily.timer \
-    apt-daily-upgrade.service \
-    apt-daily-upgrade.timer \
-    grub-common.service \
-    grub-initrd-fallback.service \
-    e2scrub_reap.service
-do
-    systemctl mask "${service}"
-done
-
 #======================================
 # Activate services
 #--------------------------------------
-baseInsertService ssh
 baseInsertService systemd-networkd
 
 #======================================

--- a/nemos-images-reference-lunar/qemu-amd64/pre_disk_sync.sh
+++ b/nemos-images-reference-lunar/qemu-amd64/pre_disk_sync.sh
@@ -96,3 +96,8 @@ ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
 #---------------------------------------
 rm -rf /var/cache/apt
 rm -rf /var/lib/apt/lists
+
+#=======================================
+# Make sure there are no source directories left behind
+#---------------------------------------
+rm -rf /usr/src

--- a/nemos-images-reference-lunar/qemu-arm64/config.sh
+++ b/nemos-images-reference-lunar/qemu-arm64/config.sh
@@ -7,11 +7,6 @@ test -f /.kconfig && . /.kconfig
 
 set -ex
 
-#======================================
-# Setup default target, multi-user
-#--------------------------------------
-baseSetRunlevel 3
-
 #==================================
 # Allow suid tools with busybox
 #----------------------------------
@@ -36,31 +31,9 @@ rm -rf /usr/lib/x86_64-linux-gnu/gconv
 #----------------------------------
 find /usr/share/doc/ ! -iname copyright -delete 2> /dev/null || true
 
-#==================================
-# Create init symlink
-#----------------------------------
-rm -f /sbin/init
-ln -rs /lib/systemd/systemd /sbin/init
-
-#==================================
-# Mask/Disable services
-#----------------------------------
-for service in \
-    apt-daily.service \
-    apt-daily.timer \
-    apt-daily-upgrade.service \
-    apt-daily-upgrade.timer \
-    grub-common.service \
-    grub-initrd-fallback.service \
-    e2scrub_reap.service
-do
-    systemctl mask "${service}"
-done
-
 #======================================
 # Activate services
 #--------------------------------------
-baseInsertService ssh
 baseInsertService systemd-networkd
 
 #======================================

--- a/nemos-images-reference-lunar/qemu-arm64/pre_disk_sync.sh
+++ b/nemos-images-reference-lunar/qemu-arm64/pre_disk_sync.sh
@@ -96,3 +96,8 @@ ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
 #---------------------------------------
 rm -rf /var/cache/apt
 rm -rf /var/lib/apt/lists
+
+#=======================================
+# Make sure there are no source directories left behind
+#---------------------------------------
+rm -rf /usr/src


### PR DESCRIPTION
Many of the functions carried out by these scripts are already the default in Ubuntu and are therefore not required. Remove them to simplify the scripts.

Additionally, some packages seem to leave behind some header files in /usr/src; delete them to reclaim space.