### PR TITLE
Use netplan.io for network management

### DIFF
--- a/nemos-images-minimal-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-minimal-lunar/qemu-amd64/appliance.kiwi
@@ -59,6 +59,7 @@
         <package name="openssh-server"/>
         <package name="usrmerge"/>
         <package name="netbase"/>
+        <package name="netplan.io"/>
         <package name="sudo"/>
         <package name="cron"/>
         <package name="zstd"/>

--- a/nemos-images-minimal-lunar/qemu-amd64/pre_disk_sync.sh
+++ b/nemos-images-minimal-lunar/qemu-amd64/pre_disk_sync.sh
@@ -47,10 +47,6 @@ for package in \
     libgnutls30 \
     libstdc++6 \
     apt \
-    python3 \
-    python3.10 \
-    python3-minimal \
-    python3.10-minimal \
     perl-base \
     debianutils
 do

--- a/nemos-images-minimal-lunar/qemu-amd64/pre_disk_sync.sh
+++ b/nemos-images-minimal-lunar/qemu-amd64/pre_disk_sync.sh
@@ -100,3 +100,8 @@ ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
 #---------------------------------------
 rm -rf /var/cache/apt
 rm -rf /var/lib/apt/lists
+
+#=======================================
+# Make sure there are no source directories left behind
+#---------------------------------------
+rm -rf /usr/src

--- a/nemos-images-minimal-lunar/qemu-amd64/root/etc/netplan/00-netplan.yaml
+++ b/nemos-images-minimal-lunar/qemu-amd64/root/etc/netplan/00-netplan.yaml
@@ -1,0 +1,11 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    lan0:
+      match:
+        driver: virtio_net
+      set-name: lan0
+      dhcp4: true
+      dhcp6: true
+      optional: false

--- a/nemos-images-minimal-lunar/qemu-amd64/root/etc/systemd/network/20-local.network
+++ b/nemos-images-minimal-lunar/qemu-amd64/root/etc/systemd/network/20-local.network
@@ -1,5 +1,0 @@
-[Match]
-Name=lan0
-
-[Network]
-DHCP=yes

--- a/nemos-images-minimal-lunar/qemu-amd64/root/etc/udev/rules.d/70-persistent-net.rules
+++ b/nemos-images-minimal-lunar/qemu-amd64/root/etc/udev/rules.d/70-persistent-net.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="?*", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="?*", NAME="lan0"

--- a/nemos-images-minimal-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-minimal-lunar/qemu-arm64/appliance.kiwi
@@ -59,6 +59,7 @@
         <package name="openssh-server"/>
         <package name="usrmerge"/>
         <package name="netbase"/>
+        <package name="netplan.io"/>
         <package name="sudo"/>
         <package name="cron"/>
         <package name="zstd"/>

--- a/nemos-images-minimal-lunar/qemu-arm64/pre_disk_sync.sh
+++ b/nemos-images-minimal-lunar/qemu-arm64/pre_disk_sync.sh
@@ -69,10 +69,6 @@ for package in \
     libgnutls30 \
     libstdc++6 \
     apt \
-    python3 \
-    python3.10 \
-    python3-minimal \
-    python3.10-minimal \
     perl-base \
     debianutils \
     qemu-system-arm \

--- a/nemos-images-minimal-lunar/qemu-arm64/pre_disk_sync.sh
+++ b/nemos-images-minimal-lunar/qemu-arm64/pre_disk_sync.sh
@@ -124,3 +124,8 @@ ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
 #---------------------------------------
 rm -rf /var/cache/apt
 rm -rf /var/lib/apt/lists
+
+#=======================================
+# Make sure there are no source directories left behind
+#---------------------------------------
+rm -rf /usr/src

--- a/nemos-images-minimal-lunar/qemu-arm64/root/etc/netplan/00-netplan.yaml
+++ b/nemos-images-minimal-lunar/qemu-arm64/root/etc/netplan/00-netplan.yaml
@@ -1,0 +1,11 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    lan0:
+      match:
+        driver: virtio_net
+      set-name: lan0
+      dhcp4: true
+      dhcp6: true
+      optional: false

--- a/nemos-images-minimal-lunar/qemu-arm64/root/etc/systemd/network/20-local.network
+++ b/nemos-images-minimal-lunar/qemu-arm64/root/etc/systemd/network/20-local.network
@@ -1,5 +1,0 @@
-[Match]
-Name=lan0
-
-[Network]
-DHCP=yes

--- a/nemos-images-minimal-lunar/qemu-arm64/root/etc/udev/rules.d/70-persistent-net.rules
+++ b/nemos-images-minimal-lunar/qemu-arm64/root/etc/udev/rules.d/70-persistent-net.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="?*", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="?*", NAME="lan0"

--- a/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
@@ -83,6 +83,7 @@
         <!-- Base packages -->
         <package name="usrmerge" />
         <package name="netbase" />
+        <package name="netplan.io" />
         <package name="sudo" />
         <package name="cron" />
         <package name="xz-utils" />

--- a/nemos-images-reference-lunar/qemu-amd64/pre_disk_sync.sh
+++ b/nemos-images-reference-lunar/qemu-amd64/pre_disk_sync.sh
@@ -96,3 +96,8 @@ ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
 #---------------------------------------
 rm -rf /var/cache/apt
 rm -rf /var/lib/apt/lists
+
+#=======================================
+# Make sure there are no source directories left behind
+#---------------------------------------
+rm -rf /usr/src

--- a/nemos-images-reference-lunar/qemu-amd64/root/etc/netplan/00-netplan.yaml
+++ b/nemos-images-reference-lunar/qemu-amd64/root/etc/netplan/00-netplan.yaml
@@ -1,0 +1,11 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    lan0:
+      match:
+        driver: virtio_net
+      set-name: lan0
+      dhcp4: true
+      dhcp6: true
+      optional: false

--- a/nemos-images-reference-lunar/qemu-amd64/root/etc/systemd/network/20-local.network
+++ b/nemos-images-reference-lunar/qemu-amd64/root/etc/systemd/network/20-local.network
@@ -1,5 +1,0 @@
-[Match]
-Name=lan0
-
-[Network]
-DHCP=yes

--- a/nemos-images-reference-lunar/qemu-amd64/root/etc/udev/rules.d/70-persistent-net.rules
+++ b/nemos-images-reference-lunar/qemu-amd64/root/etc/udev/rules.d/70-persistent-net.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="?*", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="?*", NAME="lan0"

--- a/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
@@ -83,6 +83,7 @@
         <!-- Base packages -->
         <package name="usrmerge" />
         <package name="netbase" />
+        <package name="netplan.io" />
         <package name="sudo" />
         <package name="cron" />
         <package name="xz-utils" />

--- a/nemos-images-reference-lunar/qemu-arm64/pre_disk_sync.sh
+++ b/nemos-images-reference-lunar/qemu-arm64/pre_disk_sync.sh
@@ -96,3 +96,8 @@ ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
 #---------------------------------------
 rm -rf /var/cache/apt
 rm -rf /var/lib/apt/lists
+
+#=======================================
+# Make sure there are no source directories left behind
+#---------------------------------------
+rm -rf /usr/src

--- a/nemos-images-reference-lunar/qemu-arm64/root/etc/netplan/00-netplan.yaml
+++ b/nemos-images-reference-lunar/qemu-arm64/root/etc/netplan/00-netplan.yaml
@@ -1,0 +1,11 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    lan0:
+      match:
+        driver: virtio_net
+      set-name: lan0
+      dhcp4: true
+      dhcp6: true
+      optional: false

--- a/nemos-images-reference-lunar/qemu-arm64/root/etc/systemd/network/20-local.network
+++ b/nemos-images-reference-lunar/qemu-arm64/root/etc/systemd/network/20-local.network
@@ -1,5 +1,0 @@
-[Match]
-Name=lan0
-
-[Network]
-DHCP=yes

--- a/nemos-images-reference-lunar/qemu-arm64/root/etc/udev/rules.d/70-persistent-net.rules
+++ b/nemos-images-reference-lunar/qemu-arm64/root/etc/udev/rules.d/70-persistent-net.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="?*", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="?*", NAME="lan0"


### PR DESCRIPTION
Replace the usage of raw systemd-networkd and udev rules with
netplan.io, which can do the job of both in one YAML file, simplifying
the network configurations.

Additionally, do not remove python3 packages from the rootfs, as these are required
for netplan.io. This particular change actually has very little effect on the disk
usage; python3.10 doesn't exist in lunar (as it uses 3.11), so removing
the package was essentially a no-op before. Removing the python3 package
basically just removes the symlink for python3 to python3.11, which also
doesn't have an impact on the rootfs size.