### PR TITLE
nemos-images-*-lunar: qemu-*: update grub parameters

### DIFF
--- a/nemos-images-minimal-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-minimal-lunar/qemu-amd64/appliance.kiwi
@@ -17,7 +17,7 @@
         <version>1.0.1</version>
         <packagemanager>apt</packagemanager>
         <type image="oem" filesystem="ext2" firmware="efi" initrd_system="dracut" overlayroot="true" overlayroot_write_partition="false" overlayroot_readonly_partsize="62" bootpartition="true" bootpartsize="120" format="qcow2" devicepersistency="by-partuuid" kernelcmdline="console=ttyS0 rd.root.overlay.readonly">
-            <bootloader name="grub2"/>
+            <bootloader name="grub2" console="serial" timeout="0" />
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>

--- a/nemos-images-minimal-lunar/qemu-amd64/root/etc/fstab.append
+++ b/nemos-images-minimal-lunar/qemu-amd64/root/etc/fstab.append
@@ -1,0 +1,1 @@
+tmpfs /tmp tmpfs defaults 0 0

--- a/nemos-images-minimal-lunar/qemu-arm64/root/etc/fstab.append
+++ b/nemos-images-minimal-lunar/qemu-arm64/root/etc/fstab.append
@@ -1,0 +1,1 @@
+tmpfs /tmp tmpfs defaults 0 0

--- a/nemos-images-minimal-lunar/run_qemu_amd64.sh
+++ b/nemos-images-minimal-lunar/run_qemu_amd64.sh
@@ -6,9 +6,22 @@ if [ -d /var/tmp/my_lunar ];then
     pushd /var/tmp/my_lunar
 fi
 
+NVRAM=$(mktemp)
+cp /usr/share/OVMF/OVMF_VARS.fd ${NVRAM}
+
 qemu-system-x86_64 \
     -m 1G \
-    -nographic \
+    --enable-kvm \
+    --smp 2 \
+    --cpu host \
+    -M q35 \
+    -drive file="/usr/share/OVMF/OVMF_CODE.fd",readonly=on,if=pflash,format=raw,unit=0 \
+    -drive file="${NVRAM}",if=pflash,format=raw,unit=1 \
     -netdev user,id=user0,hostfwd=tcp::10022-:22 \
     -device virtio-net-pci,netdev=user0 \
+    -object rng-random,filename=/dev/urandom,id=rng0 \
+    -device virtio-rng-pci,rng=rng0 \
+    -serial stdio -parallel null -monitor none -display none -vga none \
     -drive file=nemos-image-minimal-lunar.x86_64-1.0.1.qcow2,if=virtio
+
+rm ${NVRAM}

--- a/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
@@ -23,7 +23,7 @@
             bootpartition="true" bootpartsize="256" bootfilesystem="ext4" format="qcow2"
             kernelcmdline="console=ttyS0 rd.systemd.verity=1 root=/dev/mapper/verityRoot verityroot=/dev/disk/by-partlabel/p.lxreadonly overlay=/dev/mapper/luks rd.luks=yes"
             verity_blocks="all" embed_verity_metadata="true" luks_version="luks2" luks="insecure">
-            <bootloader name="grub2" />
+            <bootloader name="grub2" console="serial" timeout="0" />
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>

--- a/nemos-images-reference-lunar/qemu-amd64/root/etc/fstab.append
+++ b/nemos-images-reference-lunar/qemu-amd64/root/etc/fstab.append
@@ -1,0 +1,1 @@
+tmpfs /tmp tmpfs defaults 0 0

--- a/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
@@ -23,7 +23,7 @@
             bootpartition="true" bootpartsize="256" bootfilesystem="ext4" format="qcow2"
             kernelcmdline="console=ttyS0 rd.systemd.verity=1 root=/dev/mapper/verityRoot verityroot=/dev/disk/by-partlabel/p.lxreadonly overlay=/dev/mapper/luks rd.luks=yes"
             verity_blocks="all" embed_verity_metadata="true" luks_version="luks2" luks="insecure">
-            <bootloader name="grub2" />
+            <bootloader name="grub2" console="serial" timeout="0" />
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>

--- a/nemos-images-reference-lunar/qemu-arm64/root/etc/fstab.append
+++ b/nemos-images-reference-lunar/qemu-arm64/root/etc/fstab.append
@@ -1,0 +1,1 @@
+tmpfs /tmp tmpfs defaults 0 0

--- a/spread.yaml
+++ b/spread.yaml
@@ -24,7 +24,10 @@ backends:
         -drive file="${VM_IMAGE}",format=qcow2,if=virtio \
         -netdev user,id=user0,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22 \
         -device netdev=user0,driver=virtio-net-pci \
-        -serial null -parallel null -monitor none -display none -vga none \
+        -object rng-random,filename=/dev/urandom,id=rng0 \
+        -device virtio-rng-pci,rng=rng0 \
+        -serial telnet:127.0.0.1:$((${SSH_PORT} + 1)),server,nowait \
+        -parallel null -monitor none -display none -vga none \
         -pidfile /tmp/${SPREAD_BACKEND}-${SPREAD_SYSTEM}.pid
 
       sleep 30


### PR DESCRIPTION
Set the console to `serial` as the default `gfxterm` does not work in the VM (as the VM does not have a graphics output).

Additionally, set the timeout to `0` to remove the boot delay. This mostly invalidates the need for setting the console to `serial`, as the console won't appear, but it's helpful to explicitly set these variables in case a user wants to add a timeout for debugging purposes.