### PR TITLE
nemos-images-reference-lunar: qemu-*: use new dracut modules

### DIFF
--- a/.github/workflows/nemos-images-minimal-lunar.yaml
+++ b/.github/workflows/nemos-images-minimal-lunar.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: "Install dependencies"
         run: |
           sudo DEBIAN_FRONTEND="noninteractive" \
-            apt install -y golang ovmf qemu-system-x86
+            apt install -y golang ovmf qemu-system-x86 sshpass
       - name: "Install spread"
         run: |
           go clean -modcache

--- a/.github/workflows/nemos-images-reference-lunar.yaml
+++ b/.github/workflows/nemos-images-reference-lunar.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: "Install dependencies"
         run: |
           sudo DEBIAN_FRONTEND="noninteractive" \
-            apt install -y golang ovmf qemu-system-x86
+            apt install -y golang ovmf qemu-system-x86 sshpass
       - name: "Install spread"
         run: |
           go clean -modcache

--- a/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
@@ -21,7 +21,7 @@
             overlayroot="true" overlayroot_write_partition="true"
             overlayroot_readonly_partsize="1024" squashfscompression="zstd"
             bootpartition="true" bootpartsize="256" bootfilesystem="ext4" format="qcow2"
-            kernelcmdline="console=ttyS0 rd.systemd.verity=1 root=/dev/mapper/verityRoot verityroot=/dev/disk/by-partlabel/p.lxreadonly overlay=/dev/mapper/luks rd.luks=yes"
+            kernelcmdline="console=ttyS0 rd.systemd.verity=1 root=overlay:MAPPER=verityRoot verityroot=/dev/disk/by-partlabel/p.lxreadonly rd.root.overlay.write=/dev/mapper/luks rd.luks=yes rootwait"
             verity_blocks="all" embed_verity_metadata="true" luks_version="luks2" luks="insecure">
             <bootloader name="grub2" console="serial" timeout="0" />
             <oemconfig>
@@ -64,6 +64,10 @@
         repository_gpgcheck="false">
         <source path="https://ppa.launchpadcontent.net/nemos-team/ppa/ubuntu" />
     </repository>
+    <repository type="apt-deb" alias="NemOS-Kiwi-Backports-PPA" distribution="lunar" components="main"
+        repository_gpgcheck="false">
+        <source path="https://ppa.launchpadcontent.net/nemos-team/kiwi/ubuntu" />
+    </repository>
     <repository type="apt-deb" alias="Lunar-security" distribution="lunar-security"
         components="main multiverse restricted universe" repository_gpgcheck="false">
         <source path="http://security.ubuntu.com/ubuntu" />
@@ -99,9 +103,8 @@
         <package name="busybox-static" />
         <package name="cryptsetup" />
         <package name="dracut" />
-        <!-- we should switch to using the upstream dracut's built-in modules for persistent overlays when we work out how to use them -->
-        <package name="dracut-overlay-root-persistent" />
-        <package name="dracut-kiwi-verity" />
+        <package name="kiwi-dracut-overlay" />
+        <package name="kiwi-dracut-verity" />
         <package name="dbus" />
         <package name="locales" />
         <package name="systemd" />

--- a/nemos-images-reference-lunar/qemu-amd64/root/etc/dracut.conf.d/90-preload.conf
+++ b/nemos-images-reference-lunar/qemu-amd64/root/etc/dracut.conf.d/90-preload.conf
@@ -1,3 +1,3 @@
 force_drivers+=" squashfs nls_iso8859-1 binfmt_misc virtio virtio_net overlay "
-add_dracutmodules+=" overlay-root-persistent kiwi-verity crypt "
+add_dracutmodules+=" kiwi-overlay kiwi-verity crypt "
 install_items+=" /etc/cryptsetup-keys.d/luks.key "

--- a/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
@@ -21,7 +21,7 @@
             overlayroot="true" overlayroot_write_partition="true"
             overlayroot_readonly_partsize="1024" squashfscompression="zstd"
             bootpartition="true" bootpartsize="256" bootfilesystem="ext4" format="qcow2"
-            kernelcmdline="console=ttyS0 rd.systemd.verity=1 root=/dev/mapper/verityRoot verityroot=/dev/disk/by-partlabel/p.lxreadonly overlay=/dev/mapper/luks rd.luks=yes"
+            kernelcmdline="console=ttyS0 rd.systemd.verity=1 root=overlay:MAPPER=verityRoot verityroot=/dev/disk/by-partlabel/p.lxreadonly rd.root.overlay.write=/dev/mapper/luks rd.luks=yes"
             verity_blocks="all" embed_verity_metadata="true" luks_version="luks2" luks="insecure">
             <bootloader name="grub2" console="serial" timeout="0" />
             <oemconfig>
@@ -64,6 +64,10 @@
         repository_gpgcheck="false">
         <source path="https://ppa.launchpadcontent.net/nemos-team/ppa/ubuntu" />
     </repository>
+    <repository type="apt-deb" alias="NemOS-Kiwi-Backports-PPA" distribution="lunar" components="main"
+        repository_gpgcheck="false">
+        <source path="https://ppa.launchpadcontent.net/nemos-team/kiwi/ubuntu" />
+    </repository>
     <repository type="apt-deb" alias="Lunar-security" distribution="lunar-security"
         components="main multiverse restricted universe" repository_gpgcheck="false">
         <source path="http://ports.ubuntu.com/ubuntu-ports/" />
@@ -99,9 +103,8 @@
         <package name="busybox-static" />
         <package name="cryptsetup" />
         <package name="dracut" />
-        <!-- we should switch to using the upstream dracut's built-in modules for persistent overlays when we work out how to use them -->
-        <package name="dracut-overlay-root-persistent" />
-        <package name="dracut-kiwi-verity" />
+        <package name="kiwi-dracut-overlay" />
+        <package name="kiwi-dracut-verity" />
         <package name="dbus" />
         <package name="locales" />
         <package name="systemd" />

--- a/nemos-images-reference-lunar/qemu-arm64/root/etc/dracut.conf.d/90-preload.conf
+++ b/nemos-images-reference-lunar/qemu-arm64/root/etc/dracut.conf.d/90-preload.conf
@@ -1,3 +1,3 @@
 force_drivers+=" squashfs nls_iso8859-1 binfmt_misc virtio virtio_net overlay "
-add_dracutmodules+=" overlay-root-persistent kiwi-verity crypt "
+add_dracutmodules+=" kiwi-overlay kiwi-verity crypt "
 install_items+=" /etc/cryptsetup-keys.d/luks.key "

--- a/spread.yaml
+++ b/spread.yaml
@@ -30,7 +30,16 @@ backends:
         -parallel null -monitor none -display none -vga none \
         -pidfile /tmp/${SPREAD_BACKEND}-${SPREAD_SYSTEM}.pid
 
-      sleep 60
+      # Try up to 500 times to see if the SSH connection is available earlier
+      for i in $(seq 1 500); do
+        if sshpass -p ${SPREAD_SYSTEM_PASSWORD} \
+          ssh -p ${SSH_PORT} -o ConnectTimeout=1 -o StrictHostKeyChecking=no \
+          -o UserKnownHostsFile=/dev/null \
+          ${SPREAD_SYSTEM_USERNAME}@localhost /bin/true; then
+            break;
+        fi
+      done
+
       ADDRESS 127.0.0.1:${SSH_PORT}
     discard: |
       kill -9 $(cat /tmp/${SPREAD_BACKEND}-${SPREAD_SYSTEM}.pid)

--- a/spread.yaml
+++ b/spread.yaml
@@ -30,7 +30,7 @@ backends:
         -parallel null -monitor none -display none -vga none \
         -pidfile /tmp/${SPREAD_BACKEND}-${SPREAD_SYSTEM}.pid
 
-      sleep 30
+      sleep 60
       ADDRESS 127.0.0.1:${SSH_PORT}
     discard: |
       kill -9 $(cat /tmp/${SPREAD_BACKEND}-${SPREAD_SYSTEM}.pid)

--- a/tests/spread/storage-configuration/task.yaml
+++ b/tests/spread/storage-configuration/task.yaml
@@ -30,4 +30,4 @@ execute: |
   test $(echo "${VERITY}" | awk '{ if ($1 == "mode:") print $2;}') = "readonly"
 
   # Check that / is using overlayfs
-  test $(mount | grep "on / " | awk '{ print $1;}') = "overlay"
+  test $(mount | grep "on / " | awk '{ print $1;}') = "OverlayOS_rootfs"


### PR DESCRIPTION
Use the new kiwi-dracut-overlay and kiwi-dracut-verity modules from the latest version of Kiwi instead of the custom modules.

Additionally, add the Kiwi backports PPA from the NemOS project to make use of the latest version of Kiwi.