### PR TITLE
Add nemos-images-reference-lunar and nemos-images-minimal-lunar for s32g274ardb2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -38,6 +38,7 @@ Depends:
  ${misc:Depends},
  kiwi,
  kiwi-systemdeps,
+ ssl-cert,
 Suggests: jing
 Description: Kiwi NemOS reference appliance descriptions
  Lunar image descriptions for targets for use with Kiwi which demonstrate

--- a/nemos-images-minimal-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-minimal-lunar/qemu-amd64/appliance.kiwi
@@ -53,7 +53,7 @@
 
     <packages type="image">
         <!-- kernel -->
-        <package name="linux-s32"/>
+        <package name="linux-s32-nemos"/>
         <!-- network, ssh, sudo -->
         <package name="openssh-client"/>
         <package name="openssh-server"/>

--- a/nemos-images-minimal-lunar/qemu-amd64/config.sh
+++ b/nemos-images-minimal-lunar/qemu-amd64/config.sh
@@ -4,6 +4,7 @@
 # Functions...
 #--------------------------------------
 test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
 
 set -ex
 
@@ -36,3 +37,14 @@ find /usr/share/doc/ ! -iname copyright -delete 2> /dev/null || true
 # Activate services
 #--------------------------------------
 baseInsertService systemd-networkd
+
+#=======================================
+# Update OS information
+#---------------------------------------
+echo "VARIANT=\"NemOS\"" >> /usr/lib/os-release
+echo "VARIANT_ID=\"nemos\"" >> /usr/lib/os-release
+echo "IMAGE_ID=\"${kiwi_iname}\"" >> /usr/lib/os-release
+echo "IMAGE_VERSION=\"${kiwi_iversion}\"" >> /usr/lib/os-release
+echo "BUILD_ID=\"$(date -I -u)\"" >> /usr/lib/os-release
+echo "NEMOS_HOME_URL=\"https://launchpad.net/nemos\"" >> /usr/lib/os-release
+echo "NEMOS_BUG_REPORT_URL=\"https://bugs.launchpad.net/nemos\"" >> /usr/lib/os-release

--- a/nemos-images-minimal-lunar/qemu-amd64/pre_disk_sync.sh
+++ b/nemos-images-minimal-lunar/qemu-amd64/pre_disk_sync.sh
@@ -6,7 +6,7 @@ set -ex
 #=======================================
 # Create initrd link
 #---------------------------------------
-ln -s /boot/initrd-*-s32 /boot/initrd
+ln -sr /boot/initrd-*-s32 /boot/initrd
 
 #=======================================
 # Force delete packages not needed/wanted

--- a/nemos-images-minimal-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-minimal-lunar/qemu-arm64/appliance.kiwi
@@ -53,7 +53,7 @@
 
     <packages type="image">
         <!-- kernel -->
-        <package name="linux-s32"/>
+        <package name="linux-s32-nemos"/>
         <!-- network, ssh, sudo -->
         <package name="openssh-client"/>
         <package name="openssh-server"/>

--- a/nemos-images-minimal-lunar/qemu-arm64/config.sh
+++ b/nemos-images-minimal-lunar/qemu-arm64/config.sh
@@ -5,6 +5,7 @@
 # Functions...
 #--------------------------------------
 test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
 
 set -ex
 
@@ -36,3 +37,14 @@ find /usr/share/doc/ ! -iname copyright -delete 2> /dev/null || true
 # Activate services
 #--------------------------------------
 baseInsertService systemd-networkd
+
+#=======================================
+# Update OS information
+#---------------------------------------
+echo "VARIANT=\"NemOS\"" >> /usr/lib/os-release
+echo "VARIANT_ID=\"nemos\"" >> /usr/lib/os-release
+echo "IMAGE_ID=\"${kiwi_iname}\"" >> /usr/lib/os-release
+echo "IMAGE_VERSION=\"${kiwi_iversion}\"" >> /usr/lib/os-release
+echo "BUILD_ID=\"$(date -I -u)\"" >> /usr/lib/os-release
+echo "NEMOS_HOME_URL=\"https://launchpad.net/nemos\"" >> /usr/lib/os-release
+echo "NEMOS_BUG_REPORT_URL=\"https://bugs.launchpad.net/nemos\"" >> /usr/lib/os-release

--- a/nemos-images-minimal-lunar/qemu-arm64/pre_disk_sync.sh
+++ b/nemos-images-minimal-lunar/qemu-arm64/pre_disk_sync.sh
@@ -6,7 +6,7 @@ set -ex
 #=======================================
 # Create initrd link
 #---------------------------------------
-ln -s /boot/initrd-* /boot/initrd
+ln -sr /boot/initrd-* /boot/initrd
 
 #=======================================
 # Get device tree for QEMU boot
@@ -36,7 +36,8 @@ rm /boot/qemu.dtb
 for package in \
     $(apt list --installed | grep ^linux-headers | cut -f 1 -d/) \
     $(apt list --installed | grep ^linux-modules | cut -f 1 -d/) \
-    linux-image-s32 \
+    linux-image-s32-nemos \
+    linux-s32-nemos \
     linux-firmware \
     coreutils \
     tar \

--- a/nemos-images-minimal-lunar/s32g274ardb2/appliance.kiwi
+++ b/nemos-images-minimal-lunar/s32g274ardb2/appliance.kiwi
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
+
+<image schemaversion="7.4" name="nemos-image-minimal-lunar-s32g274ardb2">
+    <description type="system">
+        <author>nemOS Team</author>
+        <contact>nemos-team@lists.launchpad.net</contact>
+        <specification>Minimal image for the NXP S32G274ARDB2</specification>
+    </description>
+
+    <profiles>
+        <profile name="bootstrapped" description="build the image using a bootstrap archive" />
+        <profile name="default" description="build the image using debootstrap" import="true" />
+    </profiles>
+
+    <preferences>
+        <version>1.0.1</version>
+        <packagemanager>apt</packagemanager>
+        <type image="oem" filesystem="ext2" firmware="custom" initrd_system="dracut"
+            overlayroot="true"
+            overlayroot_write_partition="false" overlayroot_readonly_partsize="80"
+            bootpartition="true" bootpartsize="100" format="qcow2" editbootinstall="uboot_install"
+            dosparttable_extended_layout="true" force_mbr="true"
+            squashfscompression="zstd" disk_start_sector="8192">
+            <bootloader name="custom" />
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+            <size unit="M">256</size>
+            <partitions>
+                <partition name="home" size="5" mountpoint="/home" filesystem="ext2" />
+            </partitions>
+        </type>
+    </preferences>
+
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"
+            shell="/bin/ash" />
+    </users>
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/admin" name="admin"
+            groups="users" shell="/bin/ash" />
+    </users>
+
+    <repository type="apt-deb" alias="NemOS-Bootstrap-PPA" distribution="lunar" components="main"
+        repository_gpgcheck="false" profiles="bootstrapped">
+        <source path="https://ppa.launchpadcontent.net/nemos-team/bootstrap/ubuntu" />
+    </repository>
+    <repository type="apt-deb" alias="NemOS-PPA" distribution="lunar" components="main"
+        repository_gpgcheck="false">
+        <source path="https://ppa.launchpadcontent.net/nemos-team/ppa/ubuntu" />
+    </repository>
+    <repository type="apt-deb" alias="NemOS-Kiwi-Backports-PPA" distribution="lunar"
+        components="main"
+        repository_gpgcheck="false">
+        <source path="https://ppa.launchpadcontent.net/nemos-team/kiwi/ubuntu" />
+    </repository>
+    <repository type="apt-deb" alias="Lunar-security" distribution="lunar-security"
+        components="main multiverse restricted universe" repository_gpgcheck="false">
+        <source path="http://ports.ubuntu.com/" />
+    </repository>
+    <repository type="apt-deb" alias="Lunar-updates" distribution="lunar-updates"
+        components="main multiverse restricted universe" repository_gpgcheck="false">
+        <source path="http://ports.ubuntu.com/" />
+    </repository>
+    <repository type="apt-deb" alias="Lunar" distribution="lunar"
+        components="main multiverse restricted universe" repository_gpgcheck="false">
+        <source path="http://ports.ubuntu.com/" />
+    </repository>
+
+    <packages type="image">
+        <!-- kernel -->
+        <package name="linux-s32-nemos" />
+        <!-- network, ssh, sudo -->
+        <package name="openssh-client" />
+        <package name="openssh-server" />
+        <package name="usrmerge" />
+        <package name="netbase" />
+        <package name="netplan.io" />
+        <package name="sudo" />
+        <package name="cron" />
+        <package name="zstd" />
+        <!-- bootloader -->
+        <package name="arm-trusted-firmware-s32" />
+        <package name="nemos-dev-cert" />
+        <package name="nemos-dev-key" />
+        <!-- system -->
+        <package name="systemd" />
+        <package name="dbus" />
+        <package name="dracut" />
+        <package name="locales" />
+        <package name="busybox-static" />
+    </packages>
+
+    <packages type="bootstrap" bootstrap_package="kiwi-bootstrap-lunar" profiles="bootstrapped">
+        <package name="ca-certificates" />
+        <package name="apt-transport-https" />
+    </packages>
+    <packages type="bootstrap" profiles="default">
+        <package name="ca-certificates" />
+        <package name="apt-transport-https" />
+    </packages>
+</image>

--- a/nemos-images-minimal-lunar/s32g274ardb2/config.sh
+++ b/nemos-images-minimal-lunar/s32g274ardb2/config.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+#======================================
+# Functions...
+#--------------------------------------
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+set -ex
+
+#==================================
+# Allow suid tools with busybox
+#----------------------------------
+chmod u+s /usr/bin/busybox
+
+#==================================
+# Delete initrd from kernel
+#----------------------------------
+# The kernel package provides some arbitrary initrd
+rm -f /boot/initrd*
+rm -f /boot/vmlinuz.old
+
+#==================================
+# Delete data not needed or wanted
+#----------------------------------
+rm -rf /var/backups
+rm -rf /usr/share/man
+rm -rf /usr/share/i18n
+
+#==================================
+# Delete docs but retain copyright notices
+#----------------------------------
+find /usr/share/doc/ ! -iname copyright -delete 2> /dev/null || true
+
+#======================================
+# Activate services
+#--------------------------------------
+baseInsertService systemd-networkd
+
+#=======================================
+# Update OS information
+#---------------------------------------
+echo "VARIANT=\"NemOS\"" >> /usr/lib/os-release
+echo "VARIANT_ID=\"nemos\"" >> /usr/lib/os-release
+echo "IMAGE_ID=\"${kiwi_iname}\"" >> /usr/lib/os-release
+echo "IMAGE_VERSION=\"${kiwi_iversion}\"" >> /usr/lib/os-release
+echo "BUILD_ID=\"$(date -I -u)\"" >> /usr/lib/os-release
+echo "NEMOS_HOME_URL=\"https://launchpad.net/nemos\"" >> /usr/lib/os-release
+echo "NEMOS_BUG_REPORT_URL=\"https://bugs.launchpad.net/nemos\"" >> /usr/lib/os-release
+
+#=======================================
+# Correct netplan yaml permissions
+#---------------------------------------
+chmod go-rwx /etc/netplan/00-netplan.yaml

--- a/nemos-images-minimal-lunar/s32g274ardb2/post_bootstrap.sh
+++ b/nemos-images-minimal-lunar/s32g274ardb2/post_bootstrap.sh
@@ -1,0 +1,13 @@
+#!/bin/dash
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+set -ex
+
+#=======================================
+# Set zstd as the default compression tool for dracut initrd images
+#---------------------------------------
+
+mkdir -p /etc/dracut.conf.d/
+cat > /etc/dracut.conf.d/50-enable-zstd-compression.conf << EOF
+compress="zstd"
+EOF

--- a/nemos-images-minimal-lunar/s32g274ardb2/pre_disk_sync.sh
+++ b/nemos-images-minimal-lunar/s32g274ardb2/pre_disk_sync.sh
@@ -1,0 +1,129 @@
+#!/bin/dash
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+set -ex
+
+#=======================================
+# Create initrd link
+#---------------------------------------
+ln -svr /boot/initrd-* /boot/initrd
+
+#=======================================
+# Copy bootloader files to /boot so they can be deleted from root later
+#---------------------------------------
+cp /usr/share/nemos/private.pem /boot/nemos-dev.key
+cp /usr/lib/arm-trusted-firmware-s32/s32g274ardb2/fip.s32 /boot/
+
+#=======================================
+# Copy device tree and remove unused ones
+#---------------------------------------
+mv /lib/firmware/*/device-tree/freescale/s32g274a-rdb2.dtb /boot/dtb
+rm -rf /lib/firmware/*/device-tree
+
+#=======================================
+# Force delete packages not needed/wanted
+#---------------------------------------
+for package in \
+    $(apt list --installed | grep ^linux-headers | cut -f 1 -d/) \
+    $(apt list --installed | grep ^linux-modules | cut -f 1 -d/) \
+    linux-image-s32 \
+    linux-firmware \
+    coreutils \
+    tar \
+    dmsetup \
+    cpio \
+    dracut \
+    dracut-core \
+    gcc-9-base \
+    gcc-10-base \
+    gcc-11-base \
+    kpartx \
+    pkg-config \
+    perl \
+    readline-common \
+    gpgsm \
+    gnupg-utils \
+    dirmngr \
+    gpgconf \
+    gpg \
+    findutils \
+    sed \
+    grep \
+    libparted2 \
+    libdpkg-perl \
+    libreadline8 \
+    libksba8 \
+    libtasn1-6 \
+    libgmp10 \
+    libgnutls30 \
+    libstdc++6 \
+    apt \
+    perl-base \
+    lvm \
+    $(apt list --installed | grep ^python3 | cut -f 1 -d/) \
+    $(apt list --installed | grep ^libpython3 | cut -f 1 -d/) \
+    arm-trusted-firmware-s32 \
+    debianutils \
+    u-boot-tools \
+    nemos-dev-key
+do
+    rm -f /var/lib/dpkg/info/${package}*.pre*
+    rm -f /var/lib/dpkg/info/${package}*.post*
+    packages_to_delete="${packages_to_delete} ${package}"
+done
+dpkg \
+    --remove --force-remove-reinstreq \
+    --force-remove-essential --force-depends \
+${packages_to_delete}
+
+#=======================================
+# Move coreutils to busybox
+#---------------------------------------
+for file in $(busybox --list);do
+    if [ "${file}" = "busybox" ]; then
+        continue
+    fi
+    if [ "${file}" = "init" ]; then
+        # we don't want the init from busybox
+        continue
+    fi
+    busybox rm -f /bin/$file
+    busybox ln /usr/bin/busybox /bin/$file || true
+done
+
+#=======================================
+# Create /etc/hosts
+#---------------------------------------
+cat >/etc/hosts <<- EOF
+127.0.0.1       localhost
+::1             localhost ip6-localhost ip6-loopback
+ff02::1         ip6-allnodes
+ff02::2         ip6-allrouters
+EOF
+
+#=======================================
+# Create stub resolv.conf link
+#---------------------------------------
+# kiwi cleanup has dropped stale resolv.conf
+ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
+
+#=======================================
+# Relink /var/lib/dhcp to /run (rw)
+#---------------------------------------
+(cd /var/lib && rm -rf dhcp && ln -s /run dhcp)
+
+#=======================================
+# Clean up Python
+#---------------------------------------
+rm -rf /usr/lib/python3*
+
+#=======================================
+# Remove all apt caches
+#---------------------------------------
+rm -rf /var/cache/apt
+rm -rf /var/lib/apt/lists
+
+#=======================================
+# Make sure there are no source directories left behind
+#---------------------------------------
+rm -rf /usr/src

--- a/nemos-images-minimal-lunar/s32g274ardb2/root/boot/fitImage.its
+++ b/nemos-images-minimal-lunar/s32g274ardb2/root/boot/fitImage.its
@@ -1,0 +1,67 @@
+/dts-v1/;
+
+/ {
+	description = "Ubuntu kernel, ramdisk, FDT blob and boot config for a NXP S32x board";
+	#address-cells = <1>;
+
+	images {
+		kernel-1 {
+			description = "Ubuntu kernel";
+			data = /incbin/("@@PATH@@/vmlinuz");
+			type = "kernel";
+			arch = "arm64";
+			os = "linux";
+			compression = "none";
+			load =  <0x80000000>;
+			entry = <0x80000000>;
+
+			hash-1 {
+				algo = "sha256";
+			};
+		};
+
+		ramdisk-1 {
+			description = "Ubuntu ramdisk";
+			data = /incbin/("@@PATH@@/initrd");
+			type = "ramdisk";
+			arch = "arm64";
+			os = "linux";
+			compression = "none";
+			load =  <0x90000000>;
+
+			hash-1 {
+				algo = "sha256";
+			};
+		};
+
+		fdt-1 {
+			description = "Device tree for a NXP S32x board";
+			data = /incbin/("@@PATH@@/dtb");
+			type = "flat_dt";
+			arch = "arm64";
+			compression = "none";
+			load =  <0x83000000>;
+
+			hash-1 {
+				algo = "sha256";
+			};
+		};
+	};
+
+	configurations {
+		default = "nxp-s32";
+
+		nxp-s32 {
+			description = "Boot config for a NXP S32x board";
+			kernel = "kernel-1";
+			ramdisk = "ramdisk-1";
+			fdt = "fdt-1";
+
+			signature-1 {
+				algo = "sha256,rsa2048";
+				key-name-hint = "nemos-dev";
+				sign-images = "fdt", "kernel", "ramdisk";
+			};
+		};
+	};
+};

--- a/nemos-images-minimal-lunar/s32g274ardb2/root/etc/dracut.conf.d/90-preload.conf
+++ b/nemos-images-minimal-lunar/s32g274ardb2/root/etc/dracut.conf.d/90-preload.conf
@@ -1,0 +1,1 @@
+force_drivers+=" squashfs nls_iso8859-1 "

--- a/nemos-images-minimal-lunar/s32g274ardb2/root/etc/fstab.append
+++ b/nemos-images-minimal-lunar/s32g274ardb2/root/etc/fstab.append
@@ -1,0 +1,1 @@
+tmpfs /tmp tmpfs defaults 0 0

--- a/nemos-images-minimal-lunar/s32g274ardb2/root/etc/netplan/00-netplan.yaml
+++ b/nemos-images-minimal-lunar/s32g274ardb2/root/etc/netplan/00-netplan.yaml
@@ -1,0 +1,11 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eth0:
+      match:
+        name: eth0
+      set-name: lan0
+      dhcp4: true
+      dhcp6: true
+      optional: true

--- a/nemos-images-minimal-lunar/s32g274ardb2/root/etc/sudoers
+++ b/nemos-images-minimal-lunar/s32g274ardb2/root/etc/sudoers
@@ -1,0 +1,16 @@
+Defaults always_set_home
+Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin"
+Defaults env_reset
+Defaults env_keep = "LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_ATIME LC_ALL LANGUAGE LINGUAS XDG_SESSION_COOKIE"
+
+Defaults !insults
+
+Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+Defaults targetpw   # ask for the password of the target user i.e. root
+ALL   ALL=(ALL) ALL   # WARNING! Only use this together with 'Defaults targetpw'!
+
+
+root ALL=(ALL) ALL
+
+admin ALL=(ALL) NOPASSWD: ALL

--- a/nemos-images-minimal-lunar/s32g274ardb2/root/etc/systemd/journald.conf
+++ b/nemos-images-minimal-lunar/s32g274ardb2/root/etc/systemd/journald.conf
@@ -1,0 +1,3 @@
+[Journal]
+Storage=none
+ForwardToSyslog=no

--- a/nemos-images-minimal-lunar/s32g274ardb2/root/etc/systemd/system/serial-getty@ttyLF0.service.d/override.conf
+++ b/nemos-images-minimal-lunar/s32g274ardb2/root/etc/systemd/system/serial-getty@ttyLF0.service.d/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=-/usr/sbin/agetty --autologin root --noclear --keep-baud 115200,38400,9600 ttyLF0 $TERM

--- a/nemos-images-minimal-lunar/s32g274ardb2/uboot_install
+++ b/nemos-images-minimal-lunar/s32g274ardb2/uboot_install
@@ -1,0 +1,59 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+set -ex
+
+#=======================================
+# Get base loop device name
+#---------------------------------------
+DISK_NAME="$1"
+ROOT_DEV="$2"
+LOOP_NAME="$(basename ${ROOT_DEV} | cut -f 1-2 -d'p')"
+
+#=======================================
+# Get root UUID
+#---------------------------------------
+ROOT_PARTUUID="$(blkid -s PARTUUID -o value /dev/mapper/${LOOP_NAME}p3)"
+
+#=======================================
+# Mount boot partition
+#---------------------------------------
+BOOT_MOUNT="$(mktemp -d /tmp/bootmount-XXX)"
+mount "/dev/mapper/${LOOP_NAME}p1" "${BOOT_MOUNT}" || exit 1
+
+#=======================================
+# Update boot arguments
+#---------------------------------------
+BOOTARGS="console=ttyLF0,115200 earlycon root=/dev/disk/by-partuuid/${ROOT_PARTUUID} rootwait ro"
+fdtput -p -t s "${BOOT_MOUNT}/dtb" /chosen bootargs "${BOOTARGS}"
+
+#=======================================
+# Create fit image
+#---------------------------------------
+FIT="$(mktemp)"
+sed -i "s;@@PATH@@;${BOOT_MOUNT};" "${BOOT_MOUNT}/fitImage.its"
+mkimage -f "${BOOT_MOUNT}/fitImage.its" -k "${BOOT_MOUNT}" -r "${FIT}"
+
+#=======================================
+# Install U-Boot to disk
+#---------------------------------------
+dd if="${BOOT_MOUNT}/fip.s32" of="${DISK_NAME}" \
+    seek=512 skip=512 iflag=skip_bytes oflag=seek_bytes \
+    conv=fsync,notrunc
+
+#=======================================
+# Clean up unneeded files (everything is now in the fit image)
+#---------------------------------------
+rm -rf "${BOOT_MOUNT}/"*
+
+#=======================================
+# Move files to /boot
+#---------------------------------------
+mv "${FIT}" "${BOOT_MOUNT}/fitImage"
+
+#=======================================
+# Clean up
+#---------------------------------------
+umount "${BOOT_MOUNT}"
+rmdir "${BOOT_MOUNT}"
+
+sync

--- a/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
@@ -83,7 +83,7 @@
 
     <packages type="image">
         <!-- kernel -->
-        <package name="linux-s32"/>
+        <package name="linux-s32-nemos"/>
         <!-- Base packages -->
         <package name="usrmerge" />
         <package name="netbase" />

--- a/nemos-images-reference-lunar/qemu-amd64/config.sh
+++ b/nemos-images-reference-lunar/qemu-amd64/config.sh
@@ -79,3 +79,14 @@ EOF
             model=generic-classic > /var/lib/snapd/seed/assertions/model
     fi
 done
+
+#=======================================
+# Update OS information
+#---------------------------------------
+echo "VARIANT=\"NemOS\"" >> /usr/lib/os-release
+echo "VARIANT_ID=\"nemos\"" >> /usr/lib/os-release
+echo "IMAGE_ID=\"${kiwi_iname}\"" >> /usr/lib/os-release
+echo "IMAGE_VERSION=\"${kiwi_iversion}\"" >> /usr/lib/os-release
+echo "BUILD_ID=\"$(date -I -u)\"" >> /usr/lib/os-release
+echo "NEMOS_HOME_URL=\"https://launchpad.net/nemos\"" >> /usr/lib/os-release
+echo "NEMOS_BUG_REPORT_URL=\"https://bugs.launchpad.net/nemos\"" >> /usr/lib/os-release

--- a/nemos-images-reference-lunar/qemu-amd64/pre_disk_sync.sh
+++ b/nemos-images-reference-lunar/qemu-amd64/pre_disk_sync.sh
@@ -6,7 +6,7 @@ set -ex
 #=======================================
 # Create initrd link
 #---------------------------------------
-ln -s /boot/initrd-*-s32 /boot/initrd
+ln -sr /boot/initrd-* /boot/initrd
 
 #=======================================
 # Force delete packages not needed/wanted
@@ -14,8 +14,8 @@ ln -s /boot/initrd-*-s32 /boot/initrd
 for package in \
     $(apt list --installed | grep ^linux-headers | cut -f 1 -d/) \
     $(apt list --installed | grep ^linux-modules-extra | cut -f 1 -d/) \
-    linux-image-s32 \
-    linux-s32 \
+    linux-image-s32-nemos \
+    linux-s32-nemos \
     linux-firmware \
     coreutils \
     tar \

--- a/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
@@ -83,7 +83,7 @@
 
     <packages type="image">
         <!-- kernel -->
-        <package name="linux-s32"/>
+        <package name="linux-s32-nemos"/>
         <!-- Base packages -->
         <package name="usrmerge" />
         <package name="netbase" />

--- a/nemos-images-reference-lunar/qemu-arm64/config.sh
+++ b/nemos-images-reference-lunar/qemu-arm64/config.sh
@@ -4,6 +4,7 @@
 # Functions...
 #--------------------------------------
 test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
 
 set -ex
 
@@ -78,3 +79,14 @@ EOF
             model=generic-classic > /var/lib/snapd/seed/assertions/model
     fi
 done
+
+#=======================================
+# Update OS information
+#---------------------------------------
+echo "VARIANT=\"NemOS\"" >> /usr/lib/os-release
+echo "VARIANT_ID=\"nemos\"" >> /usr/lib/os-release
+echo "IMAGE_ID=\"${kiwi_iname}\"" >> /usr/lib/os-release
+echo "IMAGE_VERSION=\"${kiwi_iversion}\"" >> /usr/lib/os-release
+echo "BUILD_ID=\"$(date -I -u)\"" >> /usr/lib/os-release
+echo "NEMOS_HOME_URL=\"https://launchpad.net/nemos\"" >> /usr/lib/os-release
+echo "NEMOS_BUG_REPORT_URL=\"https://bugs.launchpad.net/nemos\"" >> /usr/lib/os-release

--- a/nemos-images-reference-lunar/qemu-arm64/pre_disk_sync.sh
+++ b/nemos-images-reference-lunar/qemu-arm64/pre_disk_sync.sh
@@ -6,7 +6,7 @@ set -ex
 #=======================================
 # Create initrd link
 #---------------------------------------
-ln -s /boot/initrd-*-s32 /boot/initrd
+ln -sr /boot/initrd-* /boot/initrd
 
 #=======================================
 # Force delete packages not needed/wanted
@@ -14,8 +14,8 @@ ln -s /boot/initrd-*-s32 /boot/initrd
 for package in \
     $(apt list --installed | grep ^linux-headers | cut -f 1 -d/) \
     $(apt list --installed | grep ^linux-modules-extra | cut -f 1 -d/) \
-    linux-image-s32 \
-    linux-s32 \
+    linux-image-s32-nemos \
+    linux-s32-nemos \
     linux-firmware \
     coreutils \
     tar \

--- a/nemos-images-reference-lunar/s32g274ardb2/appliance.kiwi
+++ b/nemos-images-reference-lunar/s32g274ardb2/appliance.kiwi
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
+
+<image schemaversion="7.4" name="nemos-image-reference-lunar-s32g274ardb2">
+    <description type="system">
+        <author>nemOS Team</author>
+        <contact>nemos-team@lists.launchpad.net</contact>
+        <specification>Reference image for the NXP S32G274ARDB2</specification>
+    </description>
+
+    <profiles>
+        <profile name="default" description="build the image using debootstrap" import="true" />
+        <profile name="bootstrapped" description="build the image using a bootstrap archive" />
+        <profile name="development" description="build an image with development tools" />
+    </profiles>
+
+    <preferences>
+        <version>1.0.1</version>
+        <packagemanager>apt</packagemanager>
+        <type image="oem" filesystem="xfs" firmware="custom" initrd_system="dracut"
+            overlayroot="true" overlayroot_write_partition="true" disk_start_sector="8192"
+            dosparttable_extended_layout="true" force_mbr="true" devicepersistency="by-uuid"
+            overlayroot_readonly_partsize="1024" squashfscompression="zstd"
+            bootpartition="true" bootpartsize="256" bootfilesystem="ext4" format="qcow2"
+            verity_blocks="all" embed_verity_metadata="true" luks_version="luks2" luks="insecure"
+            editbootinstall="uboot_install">
+            <bootloader name="custom" />
+            <oemconfig>
+                <oem-resize>false</oem-resize>
+            </oemconfig>
+            <size unit="G">2</size>
+            <partitions>
+                <partition name="home" size="10" mountpoint="/home" filesystem="ext4" />
+            </partitions>
+            <luksformat>
+                <option name="--cipher" value="aegis128-random" />
+                <option name="--key-size" value="128" />
+                <!-- Include transparent dm-integrity support -->
+                <option name="--integrity" value="aead" />
+                <!-- Adjust pbkdf parameters to match the benchmarks on the real hardware.
+                Otherwise, the parameters will be too high and will cause OOM errors -->
+                <option name="--pbkdf" value="argon2id" />
+                <option name="--pbkdf-memory" value="238746" />
+                <option name="--pbkdf-force-iterations" value="4" />
+                <option name="--pbkdf-parallel" value="4" />
+            </luksformat>
+        </type>
+    </preferences>
+
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"
+            shell="/bin/ash" />
+    </users>
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/admin" name="admin"
+            groups="users" shell="/bin/ash" />
+    </users>
+
+    <repository type="apt-deb" alias="NemOS-Bootstrap-PPA" distribution="lunar" components="main"
+        repository_gpgcheck="false" profiles="bootstrapped,development">
+        <source path="https://ppa.launchpadcontent.net/nemos-team/bootstrap/ubuntu" />
+    </repository>
+    <repository type="apt-deb" alias="NemOS-PPA" distribution="lunar" components="main"
+        repository_gpgcheck="false">
+        <source path="https://ppa.launchpadcontent.net/nemos-team/ppa/ubuntu" />
+    </repository>
+    <repository type="apt-deb" alias="NemOS-Kiwi-Backports-PPA" distribution="lunar"
+        components="main"
+        repository_gpgcheck="false">
+        <source path="https://ppa.launchpadcontent.net/nemos-team/kiwi/ubuntu" />
+    </repository>
+    <repository type="apt-deb" alias="Lunar-security" distribution="lunar-security"
+        components="main multiverse restricted universe" repository_gpgcheck="false">
+        <source path="http://ports.ubuntu.com/ubuntu-ports/" />
+    </repository>
+    <repository type="apt-deb" alias="Lunar-updates" distribution="lunar-updates"
+        components="main multiverse restricted universe" repository_gpgcheck="false">
+        <source path="http://ports.ubuntu.com/ubuntu-ports/" />
+    </repository>
+    <repository type="apt-deb" alias="Lunar" distribution="lunar"
+        components="main multiverse restricted universe" repository_gpgcheck="false">
+        <source path="http://ports.ubuntu.com/ubuntu-ports/" />
+    </repository>
+
+    <packages type="image">
+        <!-- kernel -->
+        <package name="linux-s32-nemos" />
+        <package name="linux-tools-s32-nemos" />
+        <!-- Base packages -->
+        <package name="usrmerge" />
+        <package name="netbase" />
+        <package name="netplan.io" />
+        <package name="sudo" />
+        <package name="cron" />
+        <package name="xz-utils" />
+        <package name="zstd" />
+        <package name="tuptime" />
+        <package name="polkitd" />
+        <!-- bootloader -->
+        <package name="arm-trusted-firmware-s32" />
+        <package name="nemos-dev-cert" />
+        <package name="nemos-dev-key" />
+        <!-- system -->
+        <package name="busybox-static" />
+        <package name="cryptsetup" />
+        <package name="dracut" />
+        <package name="kiwi-dracut-overlay" />
+        <package name="kiwi-dracut-verity" />
+        <package name="dbus" />
+        <package name="locales" />
+        <package name="systemd" />
+        <package name="systemd-resolved" />
+        <package name="xfsprogs" />
+        <package name="parted" />
+        <!-- Networking tools -->
+        <package name="openssh-client" />
+        <package name="openssh-server" />
+        <package name="net-tools" />
+        <package name="bridge-utils" />
+        <package name="ethtool" />
+        <package name="openssl" />
+        <package name="tftp" />
+        <package name="linuxptp" />
+        <package name="udhcpd" />
+        <package name="udhcpc" />
+        <package name="iptables" />
+    </packages>
+
+    <packages type="image" profiles="development">
+        <!-- dev tools -->
+        <package name="vim" />
+        <!-- snaps -->
+        <package name="snapd" />
+        <package name="xdelta3" />
+        <!-- testing tools for checkbox -->
+        <package name="fwts" />
+        <package name="stress-ng" />
+        <package name="ipmitool" />
+        <package name="dmidecode" />
+        <package name="sosreport" />
+        <package name="apport" />
+        <package name="dkms" />
+        <package name="mokutil" />
+    </packages>
+
+    <!-- Bootstrap configuration -->
+    <packages type="bootstrap" bootstrap_package="kiwi-bootstrap-lunar"
+        profiles="bootstrapped,development">
+        <package name="ca-certificates" />
+        <package name="apt-transport-https" />
+    </packages>
+    <packages type="bootstrap" profiles="default">
+        <package name="ca-certificates" />
+        <package name="apt-transport-https" />
+    </packages>
+</image>

--- a/nemos-images-reference-lunar/s32g274ardb2/config.sh
+++ b/nemos-images-reference-lunar/s32g274ardb2/config.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+#======================================
+# Functions...
+#--------------------------------------
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+set -ex
+
+#==================================
+# Allow suid tools with busybox
+#----------------------------------
+chmod u+s /usr/bin/busybox
+
+#==================================
+# Delete initrd from kernel
+#----------------------------------
+# The kernel package provides some arbitrary initrd
+rm -f /boot/initrd*
+rm -f /boot/vmlinuz.old
+
+#==================================
+# Delete data not needed or wanted
+#----------------------------------
+rm -rf /var/backups
+rm -rf /usr/share/man
+rm -rf /usr/lib/x86_64-linux-gnu/gconv
+
+#==================================
+# Delete docs but retain copyright notices
+#----------------------------------
+find /usr/share/doc/ ! -iname copyright -delete 2> /dev/null || true
+
+#======================================
+# Activate services
+#--------------------------------------
+baseInsertService systemd-networkd
+
+#======================================
+# Install snaps when building with the development profile
+#--------------------------------------
+
+# The list of profiles is comma separated; change them to spaces to iterate
+# over them.
+for profile in ${kiwi_profiles//,/ }; do
+    if [ "${profile}" = "development" ]; then
+        # Use the preseeding feature of snapd to preload some snaps into the
+        # system. This will download the snaps from the global Snap Store, copy
+        # them to the snapd seed directory, and add each to the preseed YAML
+        # file to instruct snapd to install them on first boot.
+        # This requires network access to the Snap Store in Kiwi.
+        mkdir -p /var/lib/snapd/seed
+        echo "snaps": > /var/lib/snapd/seed/seed.yaml
+        for snap in snapd checkbox22 checkbox core22; do
+            snap download $snap
+            # Add this new snap to the list of seeded snaps
+            cat >> /var/lib/snapd/seed/seed.yaml << EOF
+  - name: ${snap}
+    channel: latest/stable
+    file: $(ls ${snap}_*.snap)
+EOF
+            # Checkbox snap requires classic confinement mode
+            if [ "${snap}" = "checkbox" ]; then
+                cat >> /var/lib/snapd/seed/seed.yaml << EOF
+    classic: true
+EOF
+            fi
+        done
+
+        # Copy the snap archives
+        install -Dm0644 *.snap -t /var/lib/snapd/seed/snaps/
+        # Copy the snap assertions (cryptographic signatures)
+        install -Dm0644 *.assert -t /var/lib/snapd/seed/assertions/
+
+        # Install the generic snapd model assertion so that the snaps can
+        # be verified and snapd properly initialised.
+        snap known --remote model series=16 brand-id=generic \
+            model=generic-classic > /var/lib/snapd/seed/assertions/model
+    fi
+done
+
+#=======================================
+# Update OS information
+#---------------------------------------
+echo "VARIANT=\"NemOS\"" >> /usr/lib/os-release
+echo "VARIANT_ID=\"nemos\"" >> /usr/lib/os-release
+echo "IMAGE_ID=\"${kiwi_iname}\"" >> /usr/lib/os-release
+echo "IMAGE_VERSION=\"${kiwi_iversion}\"" >> /usr/lib/os-release
+echo "BUILD_ID=\"$(date -I -u)\"" >> /usr/lib/os-release
+echo "NEMOS_HOME_URL=\"https://launchpad.net/nemos\"" >> /usr/lib/os-release
+echo "NEMOS_BUG_REPORT_URL=\"https://bugs.launchpad.net/nemos\"" >> /usr/lib/os-release
+
+#=======================================
+# Correct netplan yaml permissions
+#---------------------------------------
+chmod go-rwx /etc/netplan/00-netplan.yaml

--- a/nemos-images-reference-lunar/s32g274ardb2/post_bootstrap.sh
+++ b/nemos-images-reference-lunar/s32g274ardb2/post_bootstrap.sh
@@ -1,0 +1,13 @@
+#!/bin/dash
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+set -ex
+
+#=======================================
+# Set zstd as the default compression tool for dracut initrd images
+#---------------------------------------
+
+mkdir -p /etc/dracut.conf.d/
+cat > /etc/dracut.conf.d/50-enable-zstd-compression.conf << EOF
+compress="zstd"
+EOF

--- a/nemos-images-reference-lunar/s32g274ardb2/pre_disk_sync.sh
+++ b/nemos-images-reference-lunar/s32g274ardb2/pre_disk_sync.sh
@@ -1,0 +1,118 @@
+#!/bin/dash
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+set -ex
+
+#=======================================
+# Create initrd link
+#---------------------------------------
+ln -sr /boot/initrd-* /boot/initrd
+
+#=======================================
+# Copy bootloader files to /boot so they can be deleted from root later
+#---------------------------------------
+cp /usr/share/nemos/private.pem /boot/nemos-dev.key
+cp /usr/lib/arm-trusted-firmware-s32/s32g274ardb2/fip.s32 /boot/
+
+#=======================================
+# Copy device tree and remove unused ones
+#---------------------------------------
+mv /lib/firmware/*/device-tree/freescale/s32g274a-rdb2.dtb /boot/dtb
+rm -rf /lib/firmware/*/device-tree
+
+#=======================================
+# Force delete packages not needed/wanted
+#---------------------------------------
+for package in \
+    $(apt list --installed | grep ^linux-headers | cut -f 1 -d/) \
+    $(apt list --installed | grep ^linux-modules | cut -f 1 -d/) \
+    linux-image-s32 \
+    linux-s32 \
+    linux-firmware \
+    coreutils \
+    tar \
+    cpio \
+    dracut \
+    dracut-core \
+    gcc-9-base \
+    gcc-10-base \
+    gcc-11-base \
+    kpartx \
+    pkg-config \
+    perl \
+    readline-common \
+    gpgsm \
+    gnupg-utils \
+    dirmngr \
+    gpgconf \
+    gpg \
+    findutils \
+    sed \
+    grep \
+    libparted2 \
+    libdpkg-perl \
+    libreadline8 \
+    libksba8 \
+    libgmp10 \
+    libgnutls30 \
+    apt \
+    arm-trusted-firmware-s32 \
+    debianutils \
+    u-boot-tools \
+    nemos-dev-key
+do
+    rm -f /var/lib/dpkg/info/${package}*.pre*
+    rm -f /var/lib/dpkg/info/${package}*.post*
+    packages_to_delete="${packages_to_delete} ${package}"
+done
+dpkg \
+    --remove --force-remove-reinstreq \
+    --force-remove-essential --force-depends \
+${packages_to_delete}
+
+#=======================================
+# Move coreutils to busybox
+#---------------------------------------
+for file in $(busybox --list);do
+    if [ "${file}" = "busybox" ]; then
+        continue
+    fi
+    if [ "${file}" = "init" ]; then
+        # we don't want the init from busybox
+        continue
+    fi
+    busybox rm -f /bin/$file
+    busybox ln /usr/bin/busybox /bin/$file || true
+done
+
+#=======================================
+# Create /etc/hosts
+#---------------------------------------
+cat >/etc/hosts <<- EOF
+127.0.0.1       localhost
+::1             localhost ip6-localhost ip6-loopback
+ff02::1         ip6-allnodes
+ff02::2         ip6-allrouters
+EOF
+
+#=======================================
+# Create stub resolv.conf link
+#---------------------------------------
+# kiwi cleanup has dropped stale resolv.conf
+ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
+
+#=======================================
+# Relink /var/lib/dhcp to /run (rw)
+#---------------------------------------
+(cd /var/lib && rm -rf dhcp && ln -s /run dhcp)
+
+#=======================================
+# Remove all apt caches
+#---------------------------------------
+rm -rf /var/cache/apt
+rm -rf /var/lib/apt/lists
+
+#=======================================
+# Make sure there are no source directories left behind
+#---------------------------------------
+rm -rf /usr/src

--- a/nemos-images-reference-lunar/s32g274ardb2/root/boot/fitImage.its
+++ b/nemos-images-reference-lunar/s32g274ardb2/root/boot/fitImage.its
@@ -1,0 +1,67 @@
+/dts-v1/;
+
+/ {
+	description = "Ubuntu kernel, ramdisk, FDT blob and boot config for a NXP S32x board";
+	#address-cells = <1>;
+
+	images {
+		kernel-1 {
+			description = "Ubuntu kernel";
+			data = /incbin/("@@PATH@@/vmlinuz");
+			type = "kernel";
+			arch = "arm64";
+			os = "linux";
+			compression = "none";
+			load =  <0x80000000>;
+			entry = <0x80000000>;
+
+			hash-1 {
+				algo = "sha256";
+			};
+		};
+
+		ramdisk-1 {
+			description = "Ubuntu ramdisk";
+			data = /incbin/("@@PATH@@/initrd");
+			type = "ramdisk";
+			arch = "arm64";
+			os = "linux";
+			compression = "none";
+			load =  <0x90000000>;
+
+			hash-1 {
+				algo = "sha256";
+			};
+		};
+
+		fdt-1 {
+			description = "Device tree for a NXP S32x board";
+			data = /incbin/("@@PATH@@/dtb");
+			type = "flat_dt";
+			arch = "arm64";
+			compression = "none";
+			load =  <0x83000000>;
+
+			hash-1 {
+				algo = "sha256";
+			};
+		};
+	};
+
+	configurations {
+		default = "nxp-s32";
+
+		nxp-s32 {
+			description = "Boot config for a NXP S32x board";
+			kernel = "kernel-1";
+			ramdisk = "ramdisk-1";
+			fdt = "fdt-1";
+
+			signature-1 {
+				algo = "sha256,rsa2048";
+				key-name-hint = "nemos-dev";
+				sign-images = "fdt", "kernel", "ramdisk";
+			};
+		};
+	};
+};

--- a/nemos-images-reference-lunar/s32g274ardb2/root/etc/cryptsetup-keys.d/luks.key
+++ b/nemos-images-reference-lunar/s32g274ardb2/root/etc/cryptsetup-keys.d/luks.key
@@ -1,0 +1,1 @@
+insecure

--- a/nemos-images-reference-lunar/s32g274ardb2/root/etc/dracut.conf.d/90-preload.conf
+++ b/nemos-images-reference-lunar/s32g274ardb2/root/etc/dracut.conf.d/90-preload.conf
@@ -1,0 +1,3 @@
+force_drivers+=" squashfs nls_iso8859-1 overlay "
+add_dracutmodules+=" kiwi-overlay kiwi-verity crypt "
+install_items+=" /etc/cryptsetup-keys.d/luks.key "

--- a/nemos-images-reference-lunar/s32g274ardb2/root/etc/fstab.append
+++ b/nemos-images-reference-lunar/s32g274ardb2/root/etc/fstab.append
@@ -1,0 +1,1 @@
+tmpfs /tmp tmpfs defaults 0 0

--- a/nemos-images-reference-lunar/s32g274ardb2/root/etc/netplan/00-netplan.yaml
+++ b/nemos-images-reference-lunar/s32g274ardb2/root/etc/netplan/00-netplan.yaml
@@ -1,0 +1,10 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eth0:
+      match:
+        name: eth0
+      dhcp4: true
+      dhcp6: true
+      optional: true

--- a/nemos-images-reference-lunar/s32g274ardb2/root/etc/polkit-1/localauthority/10-vendor.d/admin-org.freedesktop.login1.pkla
+++ b/nemos-images-reference-lunar/s32g274ardb2/root/etc/polkit-1/localauthority/10-vendor.d/admin-org.freedesktop.login1.pkla
@@ -1,0 +1,14 @@
+[Admin - Power off the system]
+Identity=unix-user:admin
+Action=org.freedesktop.login1.power-off
+ResultAny=yes
+
+[Admin - Reboot the system]
+Identity=unix-user:admin
+Action=org.freedesktop.login1.reboot
+ResultAny=yes
+
+[Admin - Halt the system]
+Identity=unix-user:admin
+Action=org.freedesktop.login1.halt
+ResultAny=yes

--- a/nemos-images-reference-lunar/s32g274ardb2/root/etc/sudoers
+++ b/nemos-images-reference-lunar/s32g274ardb2/root/etc/sudoers
@@ -1,0 +1,16 @@
+Defaults always_set_home
+Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin"
+Defaults env_reset
+Defaults env_keep = "LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_ATIME LC_ALL LANGUAGE LINGUAS XDG_SESSION_COOKIE"
+
+Defaults !insults
+
+Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+Defaults targetpw   # ask for the password of the target user i.e. root
+ALL   ALL=(ALL) ALL   # WARNING! Only use this together with 'Defaults targetpw'!
+
+
+root ALL=(ALL) ALL
+
+admin ALL=(ALL) NOPASSWD: ALL

--- a/nemos-images-reference-lunar/s32g274ardb2/root/etc/systemd/journald.conf
+++ b/nemos-images-reference-lunar/s32g274ardb2/root/etc/systemd/journald.conf
@@ -1,0 +1,3 @@
+[Journal]
+Storage=none
+ForwardToSyslog=no

--- a/nemos-images-reference-lunar/s32g274ardb2/root/etc/systemd/system/serial-getty@ttyLF0.service.d/override.conf
+++ b/nemos-images-reference-lunar/s32g274ardb2/root/etc/systemd/system/serial-getty@ttyLF0.service.d/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=-/usr/sbin/agetty --autologin root --noclear --keep-baud 115200,38400,9600 ttyLF0 $TERM

--- a/nemos-images-reference-lunar/s32g274ardb2/uboot_install
+++ b/nemos-images-reference-lunar/s32g274ardb2/uboot_install
@@ -1,0 +1,59 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+set -ex
+
+#=======================================
+# Get base loop device name
+#---------------------------------------
+DISK_NAME="$1"
+ROOT_DEV="$2"
+LOOP_NAME="$(basename ${ROOT_DEV} | cut -f 1-2 -d'p')"
+
+#=======================================
+# Get root UUID
+#---------------------------------------
+ROOT_PARTUUID="$(blkid -s PARTUUID -o value /dev/mapper/${LOOP_NAME}p3)"
+
+#=======================================
+# Mount boot partition
+#---------------------------------------
+BOOT_MOUNT="$(mktemp -d /tmp/bootmount-XXX)"
+mount "/dev/mapper/${LOOP_NAME}p1" "${BOOT_MOUNT}" || exit 1
+
+#=======================================
+# Update boot arguments
+#---------------------------------------
+BOOTARGS="console=ttyLF0,115200 earlycon rd.systemd.verity=1 root=overlay:MAPPER=verityRoot verityroot=/dev/disk/by-partuuid/${ROOT_PARTUUID} rd.root.overlay.write=/dev/mapper/luks rd.luks=yes rootwait"
+fdtput -p -t s "${BOOT_MOUNT}/dtb" /chosen bootargs "${BOOTARGS}"
+
+#=======================================
+# Create fit image
+#---------------------------------------
+FIT="$(mktemp)"
+sed -i "s;@@PATH@@;${BOOT_MOUNT};" "${BOOT_MOUNT}/fitImage.its"
+mkimage -f "${BOOT_MOUNT}/fitImage.its" -k "${BOOT_MOUNT}" -r "${FIT}"
+
+#=======================================
+# Install U-Boot to disk
+#---------------------------------------
+dd if="${BOOT_MOUNT}/fip.s32" of="${DISK_NAME}" \
+    seek=512 skip=512 iflag=skip_bytes oflag=seek_bytes \
+    conv=fsync,notrunc
+
+#=======================================
+# Clean up unneeded files (everything is now in the fit image)
+#---------------------------------------
+rm -rf "${BOOT_MOUNT}/"*
+
+#=======================================
+# Move files to /boot
+#---------------------------------------
+mv "${FIT}" "${BOOT_MOUNT}/fitImage"
+
+#=======================================
+# Clean up
+#---------------------------------------
+umount "${BOOT_MOUNT}"
+rmdir "${BOOT_MOUNT}"
+
+sync


### PR DESCRIPTION
This adds the minimal and reference images for the NXP s32g274ardb2 board.

Additionally, we switch to using the linux-s32-nemos kernel flavour and add information for NemOS to the /etc/os-release file