### PR TITLE
Add systemd-coredump

### DIFF
--- a/nemos-images-minimal-lunar/qemu-amd64/config.sh
+++ b/nemos-images-minimal-lunar/qemu-amd64/config.sh
@@ -26,7 +26,7 @@ rm -f /boot/vmlinuz.old
 rm -rf /var/backups
 rm -rf /usr/share/man
 rm -rf /usr/share/i18n
-rm -rf /usr/lib/x86_64-linux-gnu/gconv
+rm -rf /usr/lib/*/gconv
 
 #==================================
 # Delete docs but retain copyright notices

--- a/nemos-images-minimal-lunar/qemu-amd64/root/etc/systemd/journald.conf
+++ b/nemos-images-minimal-lunar/qemu-amd64/root/etc/systemd/journald.conf
@@ -1,3 +1,3 @@
 [Journal]
-Storage=none
+Storage=volatile
 ForwardToSyslog=no

--- a/nemos-images-minimal-lunar/qemu-arm64/config.sh
+++ b/nemos-images-minimal-lunar/qemu-arm64/config.sh
@@ -27,6 +27,7 @@ rm -f /boot/vmlinuz.old
 rm -rf /var/backups
 rm -rf /usr/share/man
 rm -rf /usr/share/i18n
+rm -rf /usr/lib/*/gconv
 
 #==================================
 # Delete docs but retain copyright notices

--- a/nemos-images-minimal-lunar/qemu-arm64/root/etc/systemd/journald.conf
+++ b/nemos-images-minimal-lunar/qemu-arm64/root/etc/systemd/journald.conf
@@ -1,3 +1,3 @@
 [Journal]
-Storage=none
+Storage=volatile
 ForwardToSyslog=no

--- a/nemos-images-minimal-lunar/s32g274ardb2/config.sh
+++ b/nemos-images-minimal-lunar/s32g274ardb2/config.sh
@@ -27,6 +27,7 @@ rm -f /boot/vmlinuz.old
 rm -rf /var/backups
 rm -rf /usr/share/man
 rm -rf /usr/share/i18n
+rm -rf /usr/lib/*/gconv
 
 #==================================
 # Delete docs but retain copyright notices

--- a/nemos-images-minimal-lunar/s32g274ardb2/root/etc/systemd/journald.conf
+++ b/nemos-images-minimal-lunar/s32g274ardb2/root/etc/systemd/journald.conf
@@ -1,3 +1,3 @@
 [Journal]
-Storage=none
+Storage=volatile
 ForwardToSyslog=no

--- a/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
@@ -109,6 +109,7 @@
         <package name="locales" />
         <package name="systemd" />
         <package name="systemd-resolved" />
+        <package name="systemd-coredump" />
         <package name="xfsprogs" />
         <package name="parted" />
         <!-- Networking tools -->

--- a/nemos-images-reference-lunar/qemu-amd64/config.sh
+++ b/nemos-images-reference-lunar/qemu-amd64/config.sh
@@ -25,7 +25,7 @@ rm -f /boot/vmlinuz.old
 #----------------------------------
 rm -rf /var/backups
 rm -rf /usr/share/man
-rm -rf /usr/lib/x86_64-linux-gnu/gconv
+rm -rf /usr/lib/*/gconv
 
 #==================================
 # Delete docs but retain copyright notices

--- a/nemos-images-reference-lunar/qemu-amd64/root/etc/systemd/journald.conf
+++ b/nemos-images-reference-lunar/qemu-amd64/root/etc/systemd/journald.conf
@@ -1,3 +1,0 @@
-[Journal]
-Storage=none
-ForwardToSyslog=no

--- a/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
@@ -109,6 +109,7 @@
         <package name="locales" />
         <package name="systemd" />
         <package name="systemd-resolved" />
+        <package name="systemd-coredump" />
         <package name="xfsprogs" />
         <package name="parted" />
         <!-- Networking tools -->

--- a/nemos-images-reference-lunar/qemu-arm64/config.sh
+++ b/nemos-images-reference-lunar/qemu-arm64/config.sh
@@ -25,7 +25,7 @@ rm -f /boot/vmlinuz.old
 #----------------------------------
 rm -rf /var/backups
 rm -rf /usr/share/man
-rm -rf /usr/lib/x86_64-linux-gnu/gconv
+rm -rf /usr/lib/*/gconv
 
 #==================================
 # Delete docs but retain copyright notices

--- a/nemos-images-reference-lunar/qemu-arm64/root/etc/systemd/journald.conf
+++ b/nemos-images-reference-lunar/qemu-arm64/root/etc/systemd/journald.conf
@@ -1,3 +1,0 @@
-[Journal]
-Storage=none
-ForwardToSyslog=no

--- a/nemos-images-reference-lunar/s32g274ardb2/appliance.kiwi
+++ b/nemos-images-reference-lunar/s32g274ardb2/appliance.kiwi
@@ -110,6 +110,7 @@
         <package name="locales" />
         <package name="systemd" />
         <package name="systemd-resolved" />
+        <package name="systemd-coredump" />
         <package name="xfsprogs" />
         <package name="parted" />
         <!-- Networking tools -->

--- a/nemos-images-reference-lunar/s32g274ardb2/config.sh
+++ b/nemos-images-reference-lunar/s32g274ardb2/config.sh
@@ -26,7 +26,7 @@ rm -f /boot/vmlinuz.old
 #----------------------------------
 rm -rf /var/backups
 rm -rf /usr/share/man
-rm -rf /usr/lib/x86_64-linux-gnu/gconv
+rm -rf /usr/lib/*/gconv
 
 #==================================
 # Delete docs but retain copyright notices

--- a/nemos-images-reference-lunar/s32g274ardb2/root/etc/systemd/journald.conf
+++ b/nemos-images-reference-lunar/s32g274ardb2/root/etc/systemd/journald.conf
@@ -1,3 +1,0 @@
-[Journal]
-Storage=none
-ForwardToSyslog=no


### PR DESCRIPTION
Add systemd-coredump to the reference images to allow capturing application core dumps. 

As part of this, re-enable journald storage as it is required by systemd-coredump.