### PR TITLE
ERL-265: nemos-images-reference-lunar: *: add admin user to log groups 

### DIFF
--- a/nemos-images-minimal-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-minimal-lunar/qemu-amd64/appliance.kiwi
@@ -30,8 +30,6 @@
 
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root" shell="/bin/ash"/>
-    </users>
-    <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/admin" name="admin" groups="users" shell="/bin/ash"/>
     </users>
 

--- a/nemos-images-minimal-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-minimal-lunar/qemu-arm64/appliance.kiwi
@@ -30,8 +30,6 @@
 
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root" shell="/bin/ash"/>
-    </users>
-    <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/admin" name="admin" groups="users" shell="/bin/ash"/>
     </users>
 

--- a/nemos-images-minimal-lunar/s32g274ardb2/appliance.kiwi
+++ b/nemos-images-minimal-lunar/s32g274ardb2/appliance.kiwi
@@ -36,8 +36,6 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"
             shell="/bin/ash" />
-    </users>
-    <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/admin" name="admin"
             groups="users" shell="/bin/ash" />
     </users>

--- a/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
@@ -50,8 +50,6 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"
             shell="/bin/ash" />
-    </users>
-    <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/admin" name="admin"
             groups="users" shell="/bin/ash" />
     </users>

--- a/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
@@ -51,7 +51,7 @@
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"
             shell="/bin/ash" />
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/admin" name="admin"
-            groups="users" shell="/bin/ash" />
+            groups="users,systemd-journal,systemd-coredump" shell="/bin/ash" />
     </users>
 
     <repository type="apt-deb" alias="NemOS-Bootstrap-PPA" distribution="lunar" components="main"

--- a/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
@@ -50,8 +50,6 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"
             shell="/bin/ash" />
-    </users>
-    <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/admin" name="admin"
             groups="users" shell="/bin/ash" />
     </users>

--- a/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
@@ -51,7 +51,7 @@
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"
             shell="/bin/ash" />
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/admin" name="admin"
-            groups="users" shell="/bin/ash" />
+            groups="users,systemd-journal,systemd-coredump" shell="/bin/ash" />
     </users>
 
     <repository type="apt-deb" alias="NemOS-Bootstrap-PPA" distribution="lunar" components="main"

--- a/nemos-images-reference-lunar/s32g274ardb2/appliance.kiwi
+++ b/nemos-images-reference-lunar/s32g274ardb2/appliance.kiwi
@@ -50,8 +50,6 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"
             shell="/bin/ash" />
-    </users>
-    <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/admin" name="admin"
             groups="users" shell="/bin/ash" />
     </users>

--- a/nemos-images-reference-lunar/s32g274ardb2/appliance.kiwi
+++ b/nemos-images-reference-lunar/s32g274ardb2/appliance.kiwi
@@ -51,7 +51,7 @@
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"
             shell="/bin/ash" />
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/admin" name="admin"
-            groups="users" shell="/bin/ash" />
+            groups="users,systemd-journal,systemd-coredump" shell="/bin/ash" />
     </users>
 
     <repository type="apt-deb" alias="NemOS-Bootstrap-PPA" distribution="lunar" components="main"


### PR DESCRIPTION
Add the admin user to the systemd-journal and systemd-coredump to demonstrate the permissions handling for controlling access to systemd logging features.