### PR TITLE
nemos-images-reference-lunar: *: remove apport in the development profile

### DIFF
--- a/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
@@ -143,7 +143,6 @@
         <package name="ipmitool" />
         <package name="dmidecode" />
         <package name="sosreport" />
-        <package name="apport" />
         <package name="dkms" />
         <package name="mokutil" />
     </packages>

--- a/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
@@ -143,7 +143,6 @@
         <package name="ipmitool" />
         <package name="dmidecode" />
         <package name="sosreport" />
-        <package name="apport" />
         <package name="dkms" />
         <package name="mokutil" />
     </packages>

--- a/nemos-images-reference-lunar/s32g274ardb2/appliance.kiwi
+++ b/nemos-images-reference-lunar/s32g274ardb2/appliance.kiwi
@@ -143,7 +143,6 @@
         <package name="ipmitool" />
         <package name="dmidecode" />
         <package name="sosreport" />
-        <package name="apport" />
         <package name="dkms" />
         <package name="mokutil" />
     </packages>


### PR DESCRIPTION
`apport` has been replaced by `systemd-coredump`, so remove `apport` from the development profile.