### PR TITLE
kernel packages: updating names

### DIFF
--- a/nemos-images-minimal-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-minimal-lunar/qemu-amd64/appliance.kiwi
@@ -53,7 +53,7 @@
 
     <packages type="image">
         <!-- kernel -->
-        <package name="linux-s32-nemos"/>
+        <package name="linux-s32-eb"/>
         <!-- network, ssh, sudo -->
         <package name="openssh-client"/>
         <package name="openssh-server"/>

--- a/nemos-images-minimal-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-minimal-lunar/qemu-arm64/appliance.kiwi
@@ -53,7 +53,7 @@
 
     <packages type="image">
         <!-- kernel -->
-        <package name="linux-s32-nemos"/>
+        <package name="linux-s32-eb"/>
         <!-- network, ssh, sudo -->
         <package name="openssh-client"/>
         <package name="openssh-server"/>

--- a/nemos-images-minimal-lunar/qemu-arm64/pre_disk_sync.sh
+++ b/nemos-images-minimal-lunar/qemu-arm64/pre_disk_sync.sh
@@ -36,8 +36,8 @@ rm /boot/qemu.dtb
 for package in \
     $(apt list --installed | grep ^linux-headers | cut -f 1 -d/) \
     $(apt list --installed | grep ^linux-modules | cut -f 1 -d/) \
-    linux-image-s32-nemos \
-    linux-s32-nemos \
+    linux-image-s32-eb \
+    linux-s32-eb \
     linux-firmware \
     coreutils \
     tar \

--- a/nemos-images-minimal-lunar/s32g274ardb2/appliance.kiwi
+++ b/nemos-images-minimal-lunar/s32g274ardb2/appliance.kiwi
@@ -70,7 +70,7 @@
 
     <packages type="image">
         <!-- kernel -->
-        <package name="linux-s32-nemos" />
+        <package name="linux-s32-eb" />
         <!-- network, ssh, sudo -->
         <package name="openssh-client" />
         <package name="openssh-server" />

--- a/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
@@ -83,8 +83,8 @@
 
     <packages type="image">
         <!-- kernel -->
-        <package name="linux-s32-nemos"/>
-        <package name="linux-tools-s32-nemos"/>
+        <package name="linux-s32-eb"/>
+        <package name="linux-tools-s32-eb"/>
         <!-- Base packages -->
         <package name="usrmerge" />
         <package name="netbase" />

--- a/nemos-images-reference-lunar/qemu-amd64/pre_disk_sync.sh
+++ b/nemos-images-reference-lunar/qemu-amd64/pre_disk_sync.sh
@@ -14,8 +14,8 @@ ln -sr /boot/initrd-* /boot/initrd
 for package in \
     $(apt list --installed | grep ^linux-headers | cut -f 1 -d/) \
     $(apt list --installed | grep ^linux-modules-extra | cut -f 1 -d/) \
-    linux-image-s32-nemos \
-    linux-s32-nemos \
+    linux-image-s32-eb \
+    linux-s32-eb \
     linux-firmware \
     coreutils \
     tar \

--- a/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
@@ -83,8 +83,8 @@
 
     <packages type="image">
         <!-- kernel -->
-        <package name="linux-s32-nemos"/>
-        <package name="linux-tools-s32-nemos"/>
+        <package name="linux-s32-eb"/>
+        <package name="linux-tools-s32-eb"/>
         <!-- Base packages -->
         <package name="usrmerge" />
         <package name="netbase" />

--- a/nemos-images-reference-lunar/qemu-arm64/pre_disk_sync.sh
+++ b/nemos-images-reference-lunar/qemu-arm64/pre_disk_sync.sh
@@ -14,8 +14,8 @@ ln -sr /boot/initrd-* /boot/initrd
 for package in \
     $(apt list --installed | grep ^linux-headers | cut -f 1 -d/) \
     $(apt list --installed | grep ^linux-modules-extra | cut -f 1 -d/) \
-    linux-image-s32-nemos \
-    linux-s32-nemos \
+    linux-image-s32-eb \
+    linux-s32-eb \
     linux-firmware \
     coreutils \
     tar \

--- a/nemos-images-reference-lunar/s32g274ardb2/appliance.kiwi
+++ b/nemos-images-reference-lunar/s32g274ardb2/appliance.kiwi
@@ -84,8 +84,8 @@
 
     <packages type="image">
         <!-- kernel -->
-        <package name="linux-s32-nemos" />
-        <package name="linux-tools-s32-nemos" />
+        <package name="linux-s32-eb" />
+        <package name="linux-tools-s32-eb" />
         <!-- Base packages -->
         <package name="usrmerge" />
         <package name="netbase" />


### PR DESCRIPTION
Following the split of generic kernel into linux-s32 and Elektrobit variant into linux-s32-eb