### PR TITLE
ERL-294: nemos-images-reference-lunar: qemu-*: enable pstore support and usage

### DIFF
--- a/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
@@ -21,7 +21,7 @@
             overlayroot="true" overlayroot_write_partition="true"
             overlayroot_readonly_partsize="1024" squashfscompression="zstd"
             bootpartition="true" bootpartsize="256" bootfilesystem="ext4" format="qcow2"
-            kernelcmdline="console=ttyS0 rd.systemd.verity=1 root=overlay:MAPPER=verityRoot verityroot=/dev/disk/by-partlabel/p.lxreadonly rd.root.overlay.write=/dev/mapper/luks rd.luks=yes rootwait"
+            kernelcmdline="console=ttyS0 rd.systemd.verity=1 root=overlay:MAPPER=verityRoot verityroot=/dev/disk/by-partlabel/p.lxreadonly rd.root.overlay.write=/dev/mapper/luks rd.luks=yes rootwait pstore.backend=efi"
             verity_blocks="all" embed_verity_metadata="true" luks_version="luks2" luks="insecure">
             <bootloader name="grub2" console="console" timeout="0" />
             <oemconfig>

--- a/nemos-images-reference-lunar/qemu-amd64/root/etc/dracut.conf.d/91-pstore.conf
+++ b/nemos-images-reference-lunar/qemu-amd64/root/etc/dracut.conf.d/91-pstore.conf
@@ -1,0 +1,1 @@
+force_drivers+=" efi-pstore "

--- a/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
@@ -21,7 +21,7 @@
             overlayroot="true" overlayroot_write_partition="true"
             overlayroot_readonly_partsize="1024" squashfscompression="zstd"
             bootpartition="true" bootpartsize="256" bootfilesystem="ext4" format="qcow2"
-            kernelcmdline="console=ttyS0 rd.systemd.verity=1 root=overlay:MAPPER=verityRoot verityroot=/dev/disk/by-partlabel/p.lxreadonly rd.root.overlay.write=/dev/mapper/luks rd.luks=yes"
+            kernelcmdline="console=ttyS0 rd.systemd.verity=1 root=overlay:MAPPER=verityRoot verityroot=/dev/disk/by-partlabel/p.lxreadonly rd.root.overlay.write=/dev/mapper/luks rd.luks=yes pstore.backend=efi"
             verity_blocks="all" embed_verity_metadata="true" luks_version="luks2" luks="insecure">
             <bootloader name="grub2" console="console" timeout="0" />
             <oemconfig>

--- a/nemos-images-reference-lunar/qemu-arm64/root/etc/dracut.conf.d/91-pstore.conf
+++ b/nemos-images-reference-lunar/qemu-arm64/root/etc/dracut.conf.d/91-pstore.conf
@@ -1,0 +1,1 @@
+force_drivers+=" efi-pstore "


### PR DESCRIPTION
Add the ability to make use of the EFI variable storage to enable pstore functionality, which allows saving kernel logs to the EFI storage in case of kernel crashes.