### PR TITLE
ERL-293: nemos-images-reference-lunar: add kdump-tools package

### DIFF
--- a/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-amd64/appliance.kiwi
@@ -126,6 +126,7 @@
         <package name="udhcpc" />
         <package name="iptables" />
         <!-- debugging tools -->
+        <package name="kdump-tools" />
         <package name="strace" />
         <package name="systemtap" />
     </packages>

--- a/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
+++ b/nemos-images-reference-lunar/qemu-arm64/appliance.kiwi
@@ -126,6 +126,7 @@
         <package name="udhcpc" />
         <package name="iptables" />
         <!-- debugging tools -->
+        <package name="kdump-tools" />
         <package name="strace" />
         <package name="systemtap" />
     </packages>

--- a/nemos-images-reference-lunar/s32g274ardb2/appliance.kiwi
+++ b/nemos-images-reference-lunar/s32g274ardb2/appliance.kiwi
@@ -126,6 +126,7 @@
         <package name="udhcpc" />
         <package name="iptables" />
         <!-- debugging tools -->
+        <package name="kdump-tools" />
         <package name="strace" />
         <package name="systemtap" />
     </packages>


### PR DESCRIPTION
Sample output on the system:

```
# kdump-config show
DUMP_MODE:              kdump
USE_KDUMP:              1
KDUMP_COREDIR:          /var/crash
crashkernel addr: 0x27000000
   /var/lib/kdump/vmlinuz: symbolic link to /boot/vmlinuz-5.15.0-1017-s32-eb
kdump initrd:
   /var/lib/kdump/initrd.img: symbolic link to /var/lib/kdump/initrd.img-5.15.0-1017-s32-eb
current state:    ready to kdump

kexec command:
  /sbin/kexec -p --command-line="BOOT_IMAGE=/vmlinuz-5.15.0-1017-s32-eb root=overlay:MAPPER=verityRoot verityroot=/dev/disk/by-partlabel/p.lxreadonly rd.root.overlay.write=/dev/mapper/luks rd.luks=yes rootwait ro console=ttyS0 rd.systemd.verity=1 verityroot=/dev/disk/by-partlabel/p.lxreadonly rd.root.overlay.write=/dev/mapper/luks rd.luks=yes rootwait pstore.backend=efi reset_devices systemd.unit=kdump-tools-dump.service nr_cpus=1 irqpoll usbcore.nousb" --initrd=/var/lib/kdump/initrd.img /var/lib/kdump/vmlinuz
```