### PR TITLE
ERL-375: nemos-images-*: *: set sysctl kernel.yama.ptrace_scope=1

### DIFF
--- a/nemos-images-minimal-lunar/qemu-amd64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-minimal-lunar/qemu-amd64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-minimal-lunar/qemu-arm64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-minimal-lunar/qemu-arm64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-minimal-lunar/s32g274ardb2/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-minimal-lunar/s32g274ardb2/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-minimal-mantic/qemu-amd64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-minimal-mantic/qemu-amd64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-minimal-mantic/qemu-arm64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-minimal-mantic/qemu-arm64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-minimal-mantic/s32g274ardb2/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-minimal-mantic/s32g274ardb2/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-reference-lunar/qemu-amd64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-reference-lunar/qemu-amd64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-reference-lunar/qemu-arm64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-reference-lunar/qemu-arm64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-reference-lunar/s32g274ardb2/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-reference-lunar/s32g274ardb2/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-reference-mantic/qemu-amd64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-reference-mantic/qemu-amd64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-reference-mantic/qemu-arm64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-reference-mantic/qemu-arm64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-reference-mantic/s32g274ardb2/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-reference-mantic/s32g274ardb2/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1


### PR DESCRIPTION
This enables restricted ptrace access, meaning a process must have a predefined relationship with the inferior it wants to call PTRACE_ATTACH on.