### PR TITLE
ERL-376: nemos-images-*: *: set sysctl kernel.kptr_restrict=1

### DIFF
--- a/nemos-images-minimal-lunar/qemu-amd64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-minimal-lunar/qemu-amd64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-minimal-lunar/qemu-arm64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-minimal-lunar/qemu-arm64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-minimal-lunar/s32g274ardb2/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-minimal-lunar/s32g274ardb2/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-minimal-mantic/qemu-amd64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-minimal-mantic/qemu-amd64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-minimal-mantic/qemu-arm64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-minimal-mantic/qemu-arm64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-minimal-mantic/s32g274ardb2/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-minimal-mantic/s32g274ardb2/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-reference-lunar/qemu-amd64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-reference-lunar/qemu-amd64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-reference-lunar/qemu-arm64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-reference-lunar/qemu-arm64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-reference-lunar/s32g274ardb2/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-reference-lunar/s32g274ardb2/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-reference-mantic/qemu-amd64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-reference-mantic/qemu-amd64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-reference-mantic/qemu-arm64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-reference-mantic/qemu-arm64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-reference-mantic/s32g274ardb2/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-reference-mantic/s32g274ardb2/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1


### PR DESCRIPTION
This setting only allows privileged users to view the kernel memory addresses.