### PR TITLE
ERL-{375,376,378,379,381}: Ensure various sysctl parameters are set

### DIFF
--- a/nemos-images-minimal-lunar/qemu-amd64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-minimal-lunar/qemu-amd64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-minimal-lunar/qemu-amd64/root/etc/sysctl.d/50-randomize-va-space.conf
+++ b/nemos-images-minimal-lunar/qemu-amd64/root/etc/sysctl.d/50-randomize-va-space.conf
@@ -1,0 +1,1 @@
+kernel.randomize_va_space=2

--- a/nemos-images-minimal-lunar/qemu-amd64/root/etc/sysctl.d/50-vm-overcommit.conf
+++ b/nemos-images-minimal-lunar/qemu-amd64/root/etc/sysctl.d/50-vm-overcommit.conf
@@ -1,0 +1,1 @@
+vm.overcommit_memory=2

--- a/nemos-images-minimal-lunar/qemu-amd64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-minimal-lunar/qemu-amd64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-minimal-lunar/qemu-arm64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-minimal-lunar/qemu-arm64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-minimal-lunar/qemu-arm64/root/etc/sysctl.d/50-randomize-va-space.conf
+++ b/nemos-images-minimal-lunar/qemu-arm64/root/etc/sysctl.d/50-randomize-va-space.conf
@@ -1,0 +1,1 @@
+kernel.randomize_va_space=2

--- a/nemos-images-minimal-lunar/qemu-arm64/root/etc/sysctl.d/50-vm-overcommit.conf
+++ b/nemos-images-minimal-lunar/qemu-arm64/root/etc/sysctl.d/50-vm-overcommit.conf
@@ -1,0 +1,1 @@
+vm.overcommit_memory=2

--- a/nemos-images-minimal-lunar/qemu-arm64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-minimal-lunar/qemu-arm64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-minimal-lunar/s32g274ardb2/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-minimal-lunar/s32g274ardb2/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-minimal-lunar/s32g274ardb2/root/etc/sysctl.d/50-randomize-va-space.conf
+++ b/nemos-images-minimal-lunar/s32g274ardb2/root/etc/sysctl.d/50-randomize-va-space.conf
@@ -1,0 +1,1 @@
+kernel.randomize_va_space=2

--- a/nemos-images-minimal-lunar/s32g274ardb2/root/etc/sysctl.d/50-vm-overcommit.conf
+++ b/nemos-images-minimal-lunar/s32g274ardb2/root/etc/sysctl.d/50-vm-overcommit.conf
@@ -1,0 +1,1 @@
+vm.overcommit_memory=2

--- a/nemos-images-minimal-lunar/s32g274ardb2/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-minimal-lunar/s32g274ardb2/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-minimal-mantic/qemu-amd64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-minimal-mantic/qemu-amd64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-minimal-mantic/qemu-amd64/root/etc/sysctl.d/50-randomize-va-space.conf
+++ b/nemos-images-minimal-mantic/qemu-amd64/root/etc/sysctl.d/50-randomize-va-space.conf
@@ -1,0 +1,1 @@
+kernel.randomize_va_space=2

--- a/nemos-images-minimal-mantic/qemu-amd64/root/etc/sysctl.d/50-vm-overcommit.conf
+++ b/nemos-images-minimal-mantic/qemu-amd64/root/etc/sysctl.d/50-vm-overcommit.conf
@@ -1,0 +1,1 @@
+vm.overcommit_memory=2

--- a/nemos-images-minimal-mantic/qemu-amd64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-minimal-mantic/qemu-amd64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-minimal-mantic/qemu-arm64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-minimal-mantic/qemu-arm64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-minimal-mantic/qemu-arm64/root/etc/sysctl.d/50-randomize-va-space.conf
+++ b/nemos-images-minimal-mantic/qemu-arm64/root/etc/sysctl.d/50-randomize-va-space.conf
@@ -1,0 +1,1 @@
+kernel.randomize_va_space=2

--- a/nemos-images-minimal-mantic/qemu-arm64/root/etc/sysctl.d/50-vm-overcommit.conf
+++ b/nemos-images-minimal-mantic/qemu-arm64/root/etc/sysctl.d/50-vm-overcommit.conf
@@ -1,0 +1,1 @@
+vm.overcommit_memory=2

--- a/nemos-images-minimal-mantic/qemu-arm64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-minimal-mantic/qemu-arm64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-minimal-mantic/s32g274ardb2/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-minimal-mantic/s32g274ardb2/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-minimal-mantic/s32g274ardb2/root/etc/sysctl.d/50-randomize-va-space.conf
+++ b/nemos-images-minimal-mantic/s32g274ardb2/root/etc/sysctl.d/50-randomize-va-space.conf
@@ -1,0 +1,1 @@
+kernel.randomize_va_space=2

--- a/nemos-images-minimal-mantic/s32g274ardb2/root/etc/sysctl.d/50-vm-overcommit.conf
+++ b/nemos-images-minimal-mantic/s32g274ardb2/root/etc/sysctl.d/50-vm-overcommit.conf
@@ -1,0 +1,1 @@
+vm.overcommit_memory=2

--- a/nemos-images-minimal-mantic/s32g274ardb2/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-minimal-mantic/s32g274ardb2/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-reference-lunar/qemu-amd64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-reference-lunar/qemu-amd64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-reference-lunar/qemu-amd64/root/etc/sysctl.d/50-randomize-va-space.conf
+++ b/nemos-images-reference-lunar/qemu-amd64/root/etc/sysctl.d/50-randomize-va-space.conf
@@ -1,0 +1,1 @@
+kernel.randomize_va_space=2

--- a/nemos-images-reference-lunar/qemu-amd64/root/etc/sysctl.d/50-vm-overcommit.conf
+++ b/nemos-images-reference-lunar/qemu-amd64/root/etc/sysctl.d/50-vm-overcommit.conf
@@ -1,0 +1,1 @@
+vm.overcommit_memory=2

--- a/nemos-images-reference-lunar/qemu-amd64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-reference-lunar/qemu-amd64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-reference-lunar/qemu-arm64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-reference-lunar/qemu-arm64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-reference-lunar/qemu-arm64/root/etc/sysctl.d/50-randomize-va-space.conf
+++ b/nemos-images-reference-lunar/qemu-arm64/root/etc/sysctl.d/50-randomize-va-space.conf
@@ -1,0 +1,1 @@
+kernel.randomize_va_space=2

--- a/nemos-images-reference-lunar/qemu-arm64/root/etc/sysctl.d/50-vm-overcommit.conf
+++ b/nemos-images-reference-lunar/qemu-arm64/root/etc/sysctl.d/50-vm-overcommit.conf
@@ -1,0 +1,1 @@
+vm.overcommit_memory=2

--- a/nemos-images-reference-lunar/qemu-arm64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-reference-lunar/qemu-arm64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-reference-lunar/s32g274ardb2/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-reference-lunar/s32g274ardb2/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-reference-lunar/s32g274ardb2/root/etc/sysctl.d/50-randomize-va-space.conf
+++ b/nemos-images-reference-lunar/s32g274ardb2/root/etc/sysctl.d/50-randomize-va-space.conf
@@ -1,0 +1,1 @@
+kernel.randomize_va_space=2

--- a/nemos-images-reference-lunar/s32g274ardb2/root/etc/sysctl.d/50-vm-overcommit.conf
+++ b/nemos-images-reference-lunar/s32g274ardb2/root/etc/sysctl.d/50-vm-overcommit.conf
@@ -1,0 +1,1 @@
+vm.overcommit_memory=2

--- a/nemos-images-reference-lunar/s32g274ardb2/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-reference-lunar/s32g274ardb2/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-reference-mantic/qemu-amd64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-reference-mantic/qemu-amd64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-reference-mantic/qemu-amd64/root/etc/sysctl.d/50-randomize-va-space.conf
+++ b/nemos-images-reference-mantic/qemu-amd64/root/etc/sysctl.d/50-randomize-va-space.conf
@@ -1,0 +1,1 @@
+kernel.randomize_va_space=2

--- a/nemos-images-reference-mantic/qemu-amd64/root/etc/sysctl.d/50-vm-overcommit.conf
+++ b/nemos-images-reference-mantic/qemu-amd64/root/etc/sysctl.d/50-vm-overcommit.conf
@@ -1,0 +1,1 @@
+vm.overcommit_memory=2

--- a/nemos-images-reference-mantic/qemu-amd64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-reference-mantic/qemu-amd64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-reference-mantic/qemu-arm64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-reference-mantic/qemu-arm64/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-reference-mantic/qemu-arm64/root/etc/sysctl.d/50-randomize-va-space.conf
+++ b/nemos-images-reference-mantic/qemu-arm64/root/etc/sysctl.d/50-randomize-va-space.conf
@@ -1,0 +1,1 @@
+kernel.randomize_va_space=2

--- a/nemos-images-reference-mantic/qemu-arm64/root/etc/sysctl.d/50-vm-overcommit.conf
+++ b/nemos-images-reference-mantic/qemu-arm64/root/etc/sysctl.d/50-vm-overcommit.conf
@@ -1,0 +1,1 @@
+vm.overcommit_memory=2

--- a/nemos-images-reference-mantic/qemu-arm64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-reference-mantic/qemu-arm64/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/nemos-images-reference-mantic/s32g274ardb2/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
+++ b/nemos-images-reference-mantic/s32g274ardb2/root/etc/sysctl.d/50-kernel-kptr-restrict.conf
@@ -1,0 +1,1 @@
+kernel.kptr_restrict=1

--- a/nemos-images-reference-mantic/s32g274ardb2/root/etc/sysctl.d/50-randomize-va-space.conf
+++ b/nemos-images-reference-mantic/s32g274ardb2/root/etc/sysctl.d/50-randomize-va-space.conf
@@ -1,0 +1,1 @@
+kernel.randomize_va_space=2

--- a/nemos-images-reference-mantic/s32g274ardb2/root/etc/sysctl.d/50-vm-overcommit.conf
+++ b/nemos-images-reference-mantic/s32g274ardb2/root/etc/sysctl.d/50-vm-overcommit.conf
@@ -1,0 +1,1 @@
+vm.overcommit_memory=2

--- a/nemos-images-reference-mantic/s32g274ardb2/root/etc/sysctl.d/50-yama-ptrace-scope.conf
+++ b/nemos-images-reference-mantic/s32g274ardb2/root/etc/sysctl.d/50-yama-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope=1

--- a/tests/spread/sysctl/task.yaml
+++ b/tests/spread/sysctl/task.yaml
@@ -1,0 +1,12 @@
+---
+
+summary: "Verify sysctl parameters"
+
+systems:
+  - "nemos-image-*"
+
+execute: |
+  test $(sysctl -n vm.overcommit_memory) = 2
+  test $(sysctl -n kernel.randomize_va_space) = 2
+  test $(sysctl -n kernel.kptr_restrict) = 1
+  test $(sysctl -n kernel.yama.ptrace_scope) = 1


### PR DESCRIPTION
This sets the following sysctl parameters across all projects:

- `vm.overcommit_memory=2`
- `kernel.randomize_va_space=2`
- `kernel.kptr_restrict=1`
- `kernel.yama.ptrace_scope=1`

Additionally, it adds a spread test to ensure that these are set in the resulting images.