### PR TITLE
ERL-424: run_qemu.sh: increase default RAM size

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -3,7 +3,7 @@
 
 set -eo pipefail
 
-RAM="1G"
+RAM="2G"
 SMP="2"
 HOST_ARCH="$(uname -m)"
 ARCH=""


### PR DESCRIPTION
With kdump-tools reserving a large chunk of RAM, there is not enough RAM leftover for testing with snapd. Increase the default RAM size to get around this.