### PR TITLE
ERL-466: nemos-images-*-mantic: qemu-*: fix EFI boot on Grub 2.12

### DIFF
--- a/nemos-images-minimal-mantic/qemu-amd64/appliance.kiwi
+++ b/nemos-images-minimal-mantic/qemu-amd64/appliance.kiwi
@@ -18,9 +18,9 @@
         <packagemanager>apt</packagemanager>
         <type image="oem" filesystem="ext2" firmware="efi" initrd_system="dracut" overlayroot="true"
             overlayroot_write_partition="false" overlayroot_readonly_partsize="62"
-            bootpartition="true" bootpartsize="120" format="qcow2" devicepersistency="by-partuuid"
-            kernelcmdline="console=ttyS0 root=overlay:PARTLABEL=p.lxreadonly rd.root.overlay.readonly">
-            <bootloader name="grub2" console="console" timeout="0" />
+            editbootconfig="install_grub.sh"
+            bootpartition="true" bootpartsize="120" format="qcow2" devicepersistency="by-partuuid">
+            <bootloader name="custom" />
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
@@ -69,6 +69,7 @@
         <package name="cron"/>
         <package name="zstd"/>
         <!-- bootloader -->
+        <package name="shim-signed" />
         <package name="grub-pc" />
         <package name="grub-efi-amd64-signed" />
         <!-- system -->

--- a/nemos-images-minimal-mantic/qemu-amd64/install_grub.sh
+++ b/nemos-images-minimal-mantic/qemu-amd64/install_grub.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -ex
+
+# Kiwi is incompatible with Grub 2.12 (as of Kiwi version 9.25.17)
+# We need to install and configure it manually.
+
+# Construct the EFI partition according to the standard Ubuntu layout using
+# signed images.
+install -vD usr/lib/shim/shimx64.efi.signed.latest \
+        boot/efi/EFI/BOOT/BOOTX64.EFI
+install -vD usr/lib/shim/shimx64.efi.signed.latest \
+        boot/efi/EFI/UBUNTU/SHIMX64.EFI
+install -vD usr/lib/shim/fbx64.efi \
+        boot/efi/EFI/BOOT/FBX64.EFI
+install -vD usr/lib/shim/mmx64.efi \
+        boot/efi/EFI/BOOT/MMX64.EFI
+install -vD usr/lib/shim/BOOTX64.CSV \
+        boot/efi/EFI/UBUNTU/BOOTX64.CSV
+install -vD usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed \
+        boot/efi/EFI/UBUNTU/GRUBX64.EFI
+
+# Tell Grub to load its config from the BOOT partition
+cat > boot/efi/EFI/UBUNTU/grub.cfg << EOF
+search.fs_label BOOT root
+set prefix=(\$root)'/grub'
+configfile \$prefix/grub.cfg
+EOF
+
+# Install Grub modules
+mkdir -p /boot/grub
+cp -rv usr/lib/grub/x86_64-efi/*.mod boot/grub/
+
+# Basic Grub configuration to load the kernel and initrd
+KERNEL="$(basename boot/vmlinuz-*)"
+INITRD="$(basename boot/initrd.img-*)"
+cat > boot/grub/grub.cfg << EOF
+linux /${KERNEL} console=ttyS0 root=overlay:PARTLABEL=p.lxreadonly rd.root.overlay.readonly selinux=0
+initrd /${INITRD}
+boot
+EOF

--- a/nemos-images-minimal-mantic/qemu-arm64/appliance.kiwi
+++ b/nemos-images-minimal-mantic/qemu-arm64/appliance.kiwi
@@ -18,9 +18,9 @@
         <packagemanager>apt</packagemanager>
         <type image="oem" filesystem="ext2" firmware="efi" initrd_system="dracut" overlayroot="true"
             overlayroot_write_partition="false" overlayroot_readonly_partsize="62"
-            bootpartition="true" bootpartsize="128" bootfilesystem="ext4" format="qcow2"
-            kernelcmdline="console=ttyS0 root=overlay:PARTLABEL=p.lxreadonly rd.root.overlay.readonly">
-            <bootloader name="grub2" console="console" timeout="0" />
+            editbootconfig="install_grub.sh"
+            bootpartition="true" bootpartsize="128" bootfilesystem="ext4" format="qcow2">
+            <bootloader name="custom" />
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
@@ -69,6 +69,7 @@
         <package name="cron"/>
         <package name="zstd"/>
         <!-- bootloader -->
+        <package name="shim-signed" />
         <package name="grub2-common" />
         <package name="grub-efi-arm64-signed" />
         <!-- system -->

--- a/nemos-images-minimal-mantic/qemu-arm64/install_grub.sh
+++ b/nemos-images-minimal-mantic/qemu-arm64/install_grub.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -ex
+
+# Kiwi is incompatible with Grub 2.12 (as of Kiwi version 9.25.17)
+# We need to install and configure it manually.
+
+# Construct the EFI partition according to the standard Ubuntu layout using
+# signed images.
+install -vD usr/lib/shim/shimaa64.efi.signed.latest \
+        boot/efi/EFI/BOOT/BOOTAA64.EFI
+install -vD usr/lib/shim/shimaa64.efi.signed.latest \
+        boot/efi/EFI/UBUNTU/SHIMAA64.EFI
+install -vD usr/lib/shim/fbaa64.efi \
+        boot/efi/EFI/BOOT/FBAA64.EFI
+install -vD usr/lib/shim/mmaa64.efi \
+        boot/efi/EFI/BOOT/MMAA64.EFI
+install -vD usr/lib/shim/BOOTAA64.CSV \
+        boot/efi/EFI/UBUNTU/BOOTAA64.CSV
+install -vD usr/lib/grub/arm64-efi-signed/grubaa64.efi.signed \
+        boot/efi/EFI/UBUNTU/GRUBAA64.EFI
+
+# Tell Grub to load its config from the BOOT partition
+cat > boot/efi/EFI/UBUNTU/grub.cfg << EOF
+search.fs_label BOOT root
+set prefix=(\$root)'/grub'
+configfile \$prefix/grub.cfg
+EOF
+
+# Install Grub modules
+mkdir -p /boot/grub
+cp -rv usr/lib/grub/arm64-efi/*.mod boot/grub/
+
+# Basic Grub configuration to load the kernel and initrd
+KERNEL="$(basename boot/vmlinuz-*)"
+INITRD="$(basename boot/initrd.img-*)"
+cat > boot/grub/grub.cfg << EOF
+linux /${KERNEL} console=ttyS0 root=overlay:PARTLABEL=p.lxreadonly rd.root.overlay.readonly selinux=0
+initrd /${INITRD}
+boot
+EOF

--- a/nemos-images-reference-mantic/qemu-amd64/appliance.kiwi
+++ b/nemos-images-reference-mantic/qemu-amd64/appliance.kiwi
@@ -19,11 +19,11 @@
         <packagemanager>apt</packagemanager>
         <type image="oem" filesystem="xfs" firmware="efi" initrd_system="dracut"
             overlayroot="true" overlayroot_write_partition="true"
+            editbootconfig="install_grub.sh"
             overlayroot_readonly_partsize="1024" squashfscompression="zstd"
             bootpartition="true" bootpartsize="256" bootfilesystem="ext4" format="qcow2"
-            kernelcmdline="console=ttyS0 rd.systemd.verity=1 root=overlay:MAPPER=verityRoot verityroot=/dev/disk/by-partlabel/p.lxreadonly rd.root.overlay.write=/dev/mapper/luks rd.luks=yes rootwait pstore.backend=efi"
             verity_blocks="all" embed_verity_metadata="true" luks_version="luks2" luks="insecure">
-            <bootloader name="grub2" console="console" timeout="0" />
+            <bootloader name="custom" />
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
@@ -94,6 +94,7 @@
         <package name="tuptime" />
         <package name="polkitd" />
         <!-- bootloader -->
+        <package name="shim-signed" />
         <package name="grub-pc" />
         <package name="grub-efi-amd64-signed" />
         <!-- system -->

--- a/nemos-images-reference-mantic/qemu-amd64/install_grub.sh
+++ b/nemos-images-reference-mantic/qemu-amd64/install_grub.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -ex
+
+# Kiwi is incompatible with Grub 2.12 (as of Kiwi version 9.25.17)
+# We need to install and configure it manually.
+
+# Construct the EFI partition according to the standard Ubuntu layout using
+# signed images.
+install -vD usr/lib/shim/shimx64.efi.signed.latest \
+        boot/efi/EFI/BOOT/BOOTX64.EFI
+install -vD usr/lib/shim/shimx64.efi.signed.latest \
+        boot/efi/EFI/UBUNTU/SHIMX64.EFI
+install -vD usr/lib/shim/fbx64.efi \
+        boot/efi/EFI/BOOT/FBX64.EFI
+install -vD usr/lib/shim/mmx64.efi \
+        boot/efi/EFI/BOOT/MMX64.EFI
+install -vD usr/lib/shim/BOOTX64.CSV \
+        boot/efi/EFI/UBUNTU/BOOTX64.CSV
+install -vD usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed \
+        boot/efi/EFI/UBUNTU/GRUBX64.EFI
+
+# Tell Grub to load its config from the BOOT partition
+cat > boot/efi/EFI/UBUNTU/grub.cfg << EOF
+search.fs_label BOOT root
+set prefix=(\$root)'/grub'
+configfile \$prefix/grub.cfg
+EOF
+
+# Install Grub modules
+mkdir -p /boot/grub
+cp -rv usr/lib/grub/x86_64-efi/*.mod boot/grub/
+
+# Basic Grub configuration to load the kernel and initrd
+KERNEL="$(basename boot/vmlinuz-*)"
+INITRD="$(basename boot/initrd.img-*)"
+cat > boot/grub/grub.cfg << EOF
+linux /${KERNEL} console=ttyS0 rd.systemd.verity=1 root=overlay:MAPPER=verityRoot verityroot=/dev/disk/by-partlabel/p.lxreadonly rd.root.overlay.write=/dev/mapper/luks rd.luks=yes rootwait pstore.backend=efi selinux=0
+initrd /${INITRD}
+boot
+EOF

--- a/nemos-images-reference-mantic/qemu-arm64/appliance.kiwi
+++ b/nemos-images-reference-mantic/qemu-arm64/appliance.kiwi
@@ -19,11 +19,11 @@
         <packagemanager>apt</packagemanager>
         <type image="oem" filesystem="xfs" firmware="efi" initrd_system="dracut"
             overlayroot="true" overlayroot_write_partition="true"
+            editbootconfig="install_grub.sh"
             overlayroot_readonly_partsize="1024" squashfscompression="zstd"
             bootpartition="true" bootpartsize="256" bootfilesystem="ext4" format="qcow2"
-            kernelcmdline="console=ttyS0 rd.systemd.verity=1 root=overlay:MAPPER=verityRoot verityroot=/dev/disk/by-partlabel/p.lxreadonly rd.root.overlay.write=/dev/mapper/luks rd.luks=yes pstore.backend=efi"
             verity_blocks="all" embed_verity_metadata="true" luks_version="luks2" luks="insecure">
-            <bootloader name="grub2" console="console" timeout="0" />
+            <bootloader name="custom" />
             <oemconfig>
                 <oem-resize>false</oem-resize>
             </oemconfig>
@@ -94,6 +94,7 @@
         <package name="tuptime" />
         <package name="polkitd" />
         <!-- bootloader -->
+        <package name="shim-signed" />
         <package name="grub2-common" />
         <package name="grub-efi-arm64-signed" />
         <!-- system -->

--- a/nemos-images-reference-mantic/qemu-arm64/install_grub.sh
+++ b/nemos-images-reference-mantic/qemu-arm64/install_grub.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -ex
+
+# Kiwi is incompatible with Grub 2.12 (as of Kiwi version 9.25.17)
+# We need to install and configure it manually.
+
+# Construct the EFI partition according to the standard Ubuntu layout using
+# signed images.
+install -vD usr/lib/shim/shimaa64.efi.signed.latest \
+        boot/efi/EFI/BOOT/BOOTAA64.EFI
+install -vD usr/lib/shim/shimaa64.efi.signed.latest \
+        boot/efi/EFI/UBUNTU/SHIMAA64.EFI
+install -vD usr/lib/shim/fbaa64.efi \
+        boot/efi/EFI/BOOT/FBAA64.EFI
+install -vD usr/lib/shim/mmaa64.efi \
+        boot/efi/EFI/BOOT/MMAA64.EFI
+install -vD usr/lib/shim/BOOTAA64.CSV \
+        boot/efi/EFI/UBUNTU/BOOTAA64.CSV
+install -vD usr/lib/grub/arm64-efi-signed/grubaa64.efi.signed \
+        boot/efi/EFI/UBUNTU/GRUBAA64.EFI
+
+# Tell Grub to load its config from the BOOT partition
+cat > boot/efi/EFI/UBUNTU/grub.cfg << EOF
+search.fs_label BOOT root
+set prefix=(\$root)'/grub'
+configfile \$prefix/grub.cfg
+EOF
+
+# Install Grub modules
+mkdir -p /boot/grub
+cp -rv usr/lib/grub/arm64-efi/*.mod boot/grub/
+
+# Basic Grub configuration to load the kernel and initrd
+KERNEL="$(basename boot/vmlinuz-*)"
+INITRD="$(basename boot/initrd.img-*)"
+cat > boot/grub/grub.cfg << EOF
+linux /${KERNEL} console=ttyS0 rd.systemd.verity=1 root=overlay:MAPPER=verityRoot verityroot=/dev/disk/by-partlabel/p.lxreadonly rd.root.overlay.write=/dev/mapper/luks rd.luks=yes pstore.backend=efi selinux=0
+initrd /${INITRD}
+boot
+EOF


### PR DESCRIPTION
Kiwi seems to generate an invalid configuration for Grub 2.12, causing the images to fail to boot. Manually install Grub and Shim according to the standard Ubuntu UEFI layout to get around this.